### PR TITLE
fix: 将 OCR 模型打包进完整版安装程序

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -5,19 +5,6 @@ fn main() {
 
     let mut windows = tauri_build::WindowsAttributes::new();
 
-    // Conditional Assets Bundling for OCR
-    let target_dir = std::path::Path::new("../.bundle-assets");
-    let _ = std::fs::remove_dir_all(&target_dir); // clean up old
-    let _ = std::fs::create_dir_all(&target_dir);
-    if std::env::var("CARGO_FEATURE_OCR").is_ok() {
-        let source_dir = std::path::Path::new("../assets");
-        if source_dir.exists() {
-            copy_dir_all(source_dir, target_dir).expect("Failed to copy assets");
-        }
-    }
-    // create empty file to satisfy tauri bundle glob match
-    let _ = std::fs::write(target_dir.join(".keep"), "");
-
     // Define the manifest with requireAdministrator
     let manifest = r#"
         <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
@@ -38,9 +25,8 @@ fn main() {
 
     windows = windows.app_manifest(manifest);
 
-    tauri_build::try_build(
-        tauri_build::Attributes::new().windows_attributes(windows)
-    ).expect("failed to run build script");
+    tauri_build::try_build(tauri_build::Attributes::new().windows_attributes(windows))
+        .expect("failed to run build script");
 }
 
 fn get_version_from_config() -> String {
@@ -58,18 +44,4 @@ fn get_version_from_config() -> String {
         }
     }
     "0.1.0".to_string()
-}
-
-fn copy_dir_all(src: impl AsRef<std::path::Path>, dst: impl AsRef<std::path::Path>) -> std::io::Result<()> {
-    std::fs::create_dir_all(&dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        } else {
-            std::fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        }
-    }
-    Ok(())
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -95,7 +95,7 @@
         ],
         "resources": [
             "../docs/",
-            "../.bundle-assets/**/*"
+            "../assets/**/*"
         ],
         "windows": {
             "wix": {

--- a/src-tauri/tauri.lite.conf.json
+++ b/src-tauri/tauri.lite.conf.json
@@ -1,4 +1,9 @@
 {
   "productName": "D2RHub Lite",
-  "identifier": "com.d2rhub.lite.app"
+  "identifier": "com.d2rhub.lite.app",
+  "bundle": {
+    "resources": [
+      "../docs/"
+    ]
+  }
 }


### PR DESCRIPTION
## 问题

完整版安装程序此前将 OCR 模型暂存到 `.bundle-assets`，导致安装后的资源路径为：

`resource_dir/_up_/.bundle-assets/models`

但 OCR 引擎读取的是：

`resource_dir/_up_/assets/models`

因此安装版无法加载 ONNX 模型。

## 修复

- 完整版直接打包 `assets/**/*`
- Lite 版明确排除 OCR 模型，仅保留文档资源
- 删除 `.bundle-assets` 临时复制逻辑
- 保持 OCR 引擎现有资源路径不变

## 验证

- `npm test` 通过
- `npm run build` 通过
- `npm run build:full` 成功生成 MSI 和 NSIS 安装包
- WiX 与 NSIS 安装清单确认 5 个 OCR 模型/字典均打包到 `_up_/assets/models`

Closes #1