### PR TITLE
fix: make Settings.json optional for multiboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ D2RHub 是一款专为《暗黑破坏神 II：重制版》(D2R) 玩家精心设�
 ### ✨ 核心特色功能
 *   **🎮 本地多开管理**：一键清除游戏的多开限制。基于 Windows 标准进程句柄清理技术，不修改游戏文件，不注入内存或 DLL。
 *   **🚀 账号独立配置**：支持为每个账号绑定独立的战网 Token 实现自动排队登录，支持独立启动参数（Mod 启动）以及独立的单机存档目录。
-*   **⚙️ 图形化画质设置**：内置画质编辑器，支持一键切换画质预设（如小号极低画质、大号超高画质），降低多开时的硬件负载。
+*   **⚙️ 图形化画质设置**：内置画质编辑器，支持一键切换画质预设（如小号极低画质、大号超高画质），降低多开时的硬件负载。存档目录缺少 `Settings.json` 时，账号创建、登录和多开仍可正常使用，仅画质配置相关功能暂不可用。
 *   **📊 硬件负载监控**：实时监控 CPU、内存、GPU 及显存占用，多开时硬件状态一目了然。
 *   **🪟 迷你悬浮窗 (Overlay)**：可置顶悬浮在桌面上，方便双击切换并聚焦对应的游戏窗口。
 *   **⏱️ OCR 智能刷图统计**：通过实时 OCR 分析游戏画面，自动记录刷图时间、历史平均用时、总场次等统计数据。
@@ -64,7 +64,7 @@ D2RHub is a lightweight, player-friendly Windows utility designed for managing m
 ### ✨ Features
 *   **🎮 Local Multi-Instance Management**: Bypass the D2R single-instance restriction automatically. D2RHub uses native Windows handle closing APIs, with no memory injection, DLL injection, or game-file modification.
 *   **🚀 Configuration Isolation**: Bind different Battle.net accounts, custom launch arguments (Mod support), and **independent save directories** for each profile.
-*   **⚙️ Graphical Settings Editor**: Tweak D2R's `Settings.json` with a full GUI. Apply graphics presets instantly (e.g., Ultra settings for your main character, Minimum settings for alt accounts to save GPU/CPU resources).
+*   **⚙️ Graphical Settings Editor**: Tweak D2R's `Settings.json` with a full GUI. Apply graphics presets instantly (e.g., Ultra settings for your main character, Minimum settings for alt accounts to save GPU/CPU resources). If the save directory does not contain `Settings.json`, profile creation, login, and multiboxing remain available; only graphics configuration features are unavailable until the path or file is fixed.
 *   **📊 Hardware Load Monitor**: Real-time tracking of CPU, RAM, GPU, and Video Memory (VRAM) so you can monitor your computer's health while multi-boxing.
 *   **🪟 Desktop Overlay**: A compact, semi-transparent overlay shows on the edge of your screen when the manager is minimized, showing hardware stats and active account status.
 *   **⏱️ OCR Run Tracker**: Real-time OCR-based game screen analysis. Automatically records run timers, average times, and session run counts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d2rhub",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d2rhub",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d2rhub",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Windows multi-account manager and OCR run tracker for Diablo II: Resurrected",
   "license": "MIT",
   "repository": {
@@ -18,6 +18,8 @@
     "build": "tsc && vite build",
     "build:full": "cross-env VITE_ENABLE_OCR=true tauri build",
     "build:lite": "cross-env VITE_ENABLE_OCR=false tauri build --config src-tauri/tauri.lite.conf.json -- --no-default-features",
+    "build:full:nsis": "cross-env VITE_ENABLE_OCR=true tauri build --bundles nsis",
+    "build:lite:nsis": "cross-env VITE_ENABLE_OCR=false tauri build --bundles nsis --config src-tauri/tauri.lite.conf.json -- --no-default-features",
     "build:all": "npm run build:full && npm run build:lite",
     "test": "node scripts/run-shortcut-tests.cjs",
     "preview": "vite preview",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "d2rhub"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d2rhub"
-version = "0.7.5"
+version = "0.7.6"
 description = "Diablo II Resurrected Multi-Account Manager"
 authors = ["D2RHub"]
 edition = "2021"

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -290,13 +290,13 @@ impl AccountManager {
     }
 }
 
-fn copy_system_settings_to_account(saved_games_path: &str, account_dir: &Path) -> Result<(), AppError> {
-    let src = Path::new(saved_games_path).join("Settings.json");
-    if !src.exists() {
-        return Err(AppError::FileError(format!(
-            "系统 Settings.json 不存在: {}",
-            src.to_string_lossy()
-        )));
+pub(crate) fn copy_system_settings_to_account_if_available(
+    saved_games_path: &Path,
+    account_dir: &Path,
+) -> Result<bool, AppError> {
+    let src = saved_games_path.join("Settings.json");
+    if !src.is_file() {
+        return Ok(false);
     }
 
     if !account_dir.exists() {
@@ -304,6 +304,29 @@ fn copy_system_settings_to_account(saved_games_path: &str, account_dir: &Path) -
     }
 
     std::fs::copy(&src, account_dir.join("Settings.json"))
+        .map_err(|e| AppError::FileError(format!("复制 Settings.json 失败: {}", e)))?;
+    Ok(true)
+}
+
+pub(crate) fn copy_account_settings_to_system(
+    account_dir: &Path,
+    saved_games_path: &Path,
+) -> Result<(), AppError> {
+    let src = account_dir.join("Settings.json");
+    if !src.is_file() {
+        return Err(AppError::FileError(format!(
+            "账号 Settings.json 不存在: {}。请先在画质配置中从系统配置创建账号独立配置",
+            src.display()
+        )));
+    }
+    if !saved_games_path.is_dir() {
+        return Err(AppError::FileError(format!(
+            "存档目录无效: {}。请在设置中修正存档目录",
+            saved_games_path.display()
+        )));
+    }
+
+    std::fs::copy(&src, saved_games_path.join("Settings.json"))
         .map_err(|e| AppError::FileError(format!("复制 Settings.json 失败: {}", e)))?;
     Ok(())
 }
@@ -469,7 +492,15 @@ pub fn create_account(
     let id = AccountManager::next_id(&cfg.accounts_dir);
     let dir = AccountManager::account_dir_checked(&cfg.accounts_dir, &id)?;
     std::fs::create_dir_all(&dir)?;
-    copy_system_settings_to_account(&cfg.saved_games_path, &dir)?;
+    if let Err(error) =
+        copy_system_settings_to_account_if_available(Path::new(&cfg.saved_games_path), &dir)
+    {
+        crate::logger::log_msg(
+            "WARN",
+            "Account",
+            &format!("创建账号时跳过可选 Settings.json 快照: {}", error),
+        );
+    }
 
     let mut meta = AccountMeta::new(&id);
     meta.display_name = nickname;
@@ -838,7 +869,15 @@ fn collect_account_snapshot_blocking(
     }
 
     // 2. 从全局存档配置路径复制真实 Settings.json
-    copy_system_settings_to_account(&cfg.saved_games_path, &account_dir)?;
+    if let Err(error) =
+        copy_system_settings_to_account_if_available(Path::new(&cfg.saved_games_path), &account_dir)
+    {
+        crate::logger::log_msg(
+            "WARN",
+            "Account",
+            &format!("初始化账号时跳过可选 Settings.json 快照: {}", error),
+        );
+    }
 
     // 3. 导出注册表
     let json_dst = account_dir.join("unified_auth.json");
@@ -881,6 +920,70 @@ fn cleanup_after_snapshot() -> Result<(), AppError> {
     kill_processes_by_name(&["Battle.net.exe", "Agent.exe"]);
     // 清空注册表
     clear_auth_registry()
+}
+
+#[cfg(test)]
+mod settings_json_tests {
+    use super::{copy_account_settings_to_system, copy_system_settings_to_account_if_available};
+    use std::path::PathBuf;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = format!(
+            "d2rhub_{name}_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let dir = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn missing_system_settings_is_optional_for_account_creation() {
+        let saved_games = temp_dir("missing_system_settings");
+        let account_dir = temp_dir("account_without_settings");
+
+        let copied =
+            copy_system_settings_to_account_if_available(&saved_games, &account_dir).unwrap();
+
+        assert!(!copied);
+        assert!(!account_dir.join("Settings.json").exists());
+        let _ = std::fs::remove_dir_all(saved_games);
+        let _ = std::fs::remove_dir_all(account_dir);
+    }
+
+    #[test]
+    fn existing_system_settings_is_copied_to_account() {
+        let saved_games = temp_dir("existing_system_settings");
+        let account_dir = temp_dir("account_with_settings");
+        std::fs::write(saved_games.join("Settings.json"), r#"{"VSync":1}"#).unwrap();
+
+        let copied =
+            copy_system_settings_to_account_if_available(&saved_games, &account_dir).unwrap();
+
+        assert!(copied);
+        assert_eq!(
+            std::fs::read_to_string(account_dir.join("Settings.json")).unwrap(),
+            r#"{"VSync":1}"#
+        );
+        let _ = std::fs::remove_dir_all(saved_games);
+        let _ = std::fs::remove_dir_all(account_dir);
+    }
+
+    #[test]
+    fn customized_settings_requires_an_account_settings_file() {
+        let saved_games = temp_dir("customized_settings_target");
+        let account_dir = temp_dir("customized_settings_source");
+
+        let error = copy_account_settings_to_system(&account_dir, &saved_games).unwrap_err();
+
+        assert!(error.to_string().contains("账号 Settings.json 不存在"));
+        let _ = std::fs::remove_dir_all(saved_games);
+        let _ = std::fs::remove_dir_all(account_dir);
+    }
 }
 
 /// 清空 UnifiedAuth 注册表键值（保留键本身）

--- a/src-tauri/src/commands/global_config.rs
+++ b/src-tauri/src/commands/global_config.rs
@@ -138,19 +138,8 @@ fn file_name_eq(path: &Path, expected: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn ensure_writable_dir(path: &Path) -> Result<(), AppError> {
-    if path.join("Settings.json").is_file() {
-        return Ok(());
-    }
-
-    let probe = path.join(format!(
-        ".d2rhub_write_test_{}.tmp",
-        std::process::id()
-    ));
-    std::fs::write(&probe, b"")
-        .map_err(|e| AppError::ConfigWriteError(format!("存档目录不可写 {}: {}", path.display(), e)))?;
-    let _ = std::fs::remove_file(probe);
-    Ok(())
+fn saved_games_settings_exists(path: &Path) -> bool {
+    path.join("Settings.json").is_file()
 }
 
 fn validate_config_paths(config: &GlobalConfig) -> Result<(), AppError> {
@@ -163,15 +152,6 @@ fn validate_config_paths(config: &GlobalConfig) -> Result<(), AppError> {
     if !game_path.is_dir() {
         return Err(AppError::InvalidGamePath(config.game_path.clone()));
     }
-
-    let saved_games_path = Path::new(&config.saved_games_path);
-    if !saved_games_path.is_dir() {
-        return Err(AppError::ConfigWriteError(format!(
-            "存档目录无效: {}",
-            config.saved_games_path
-        )));
-    }
-    ensure_writable_dir(saved_games_path)?;
 
     if !config.browser_path.trim().is_empty() {
         let browser_path = Path::new(&config.browser_path);
@@ -200,6 +180,53 @@ fn validate_config_paths(config: &GlobalConfig) -> Result<(), AppError> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod saved_games_validation_tests {
+    use super::{saved_games_settings_exists, validate_config_paths, GlobalConfig};
+
+    fn temp_dir(name: &str) -> std::path::PathBuf {
+        let unique = format!(
+            "d2rhub_{name}_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let dir = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn invalid_saved_games_path_does_not_block_core_configuration() {
+        let root = temp_dir("config_without_saved_games");
+        let battle_net = root.join("Battle.net.exe");
+        let game_dir = root.join("game");
+        std::fs::write(&battle_net, b"").unwrap();
+        std::fs::create_dir_all(&game_dir).unwrap();
+
+        let mut config = GlobalConfig::default();
+        config.battle_net_path = battle_net.to_string_lossy().to_string();
+        config.game_path = game_dir.to_string_lossy().to_string();
+        config.saved_games_path = root.join("missing").to_string_lossy().to_string();
+
+        assert!(validate_config_paths(&config).is_ok());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn settings_availability_requires_the_actual_file() {
+        let saved_games = temp_dir("settings_availability");
+        assert!(!saved_games_settings_exists(&saved_games));
+
+        std::fs::write(saved_games.join("Settings.json"), b"{}").unwrap();
+
+        assert!(saved_games_settings_exists(&saved_games));
+        let _ = std::fs::remove_dir_all(saved_games);
+    }
 }
 
 /// 窗口几何信息（位置+尺寸持久化）
@@ -488,6 +515,11 @@ pub fn save_global_config(
     update_shortcut_map(&state, &cfg);
     crate::input_listener::set_bongo_cat_input_enabled(cfg.enable_bongo_cat);
     Ok(())
+}
+
+#[tauri::command]
+pub fn check_saved_games_settings(path: String) -> bool {
+    saved_games_settings_exists(Path::new(&path))
 }
 
 /// 保存窗口几何信息（位置+尺寸）

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::Ordering;
 use serde::{Deserialize, Serialize};
 use tauri::Emitter;
 
-use crate::commands::account::AccountManager;
+use crate::commands::account::{copy_account_settings_to_system, AccountManager};
 use crate::commands::system::LaunchProgress;
 use crate::commands::utils::silent_cmd;
 use crate::error::AppError;
@@ -358,21 +358,8 @@ async fn prepare_bnet_environment(
             .map(|meta| meta.has_customized_settings)
             .unwrap_or(false)
         {
-            let src = account_dir.join("Settings.json");
-            let dst = Path::new(&saved_games_path).join("Settings.json");
-            if src.exists() {
-                if let Some(parent) = dst.parent() {
-                    if !parent.exists() {
-                        let _ = std::fs::create_dir_all(parent);
-                    }
-                }
-                if dst.exists() {
-                    let _ = std::fs::remove_file(&dst);
-                }
-                if let Err(e) = std::fs::copy(&src, &dst) {
-                    return Err(format!("复制 Settings.json 失败: {}", e));
-                }
-            }
+            copy_account_settings_to_system(&account_dir, Path::new(&saved_games_path))
+                .map_err(|e| e.to_string())?;
         } else {
             crate::logger::log_msg(
                 "INFO",
@@ -1281,13 +1268,16 @@ async fn launch_single_token(
 
     // 1. 覆盖 Settings.json
     if meta.has_customized_settings {
-        let src = account_dir.join("Settings.json");
-        let dst = std::path::Path::new(&saved_games_path).join("Settings.json");
-        if src.exists() {
-            if let Some(parent) = dst.parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-            let _ = std::fs::copy(&src, &dst);
+        if let Err(e) =
+            copy_account_settings_to_system(&account_dir, Path::new(&saved_games_path))
+        {
+            return LaunchResult {
+                account_id: account_id.to_string(),
+                success: false,
+                d2r_pid: None,
+                error: Some(e.to_string()),
+                mutex_killed: false,
+            };
         }
     } else {
         crate::logger::log_msg(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -316,6 +316,7 @@ pub fn run() {
             commands::global_config::save_theme,
             commands::global_config::detect_battle_net_path,
             commands::global_config::detect_saved_games_path,
+            commands::global_config::check_saved_games_settings,
             commands::global_config::detect_program_data_agent_path,
             commands::global_config::detect_app_data_roaming_bnet_path,
             commands::global_config::detect_browser_path,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
     "productName": "D2RHub",
-    "version": "0.7.5",
+    "version": "0.7.6",
     "identifier": "com.d2rhub.app",
     "build": {
         "frontendDist": "../dist",

--- a/src/components/config/SettingsCenter.tsx
+++ b/src/components/config/SettingsCenter.tsx
@@ -71,10 +71,31 @@ export function SettingsCenter({ open, onClose, onReconfigure, initialTab, initi
 
   // Tab and search state
   const [activeTab, setActiveTab] = useState<TabType>("accounts");
+  const [settingsJsonAvailable, setSettingsJsonAvailable] = useState<boolean | null>(null);
 
   // Config backup for rollback
   const [originalConfig, setOriginalConfig] = useState<GlobalConfig | null>(null);
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    if (!open || !config?.saved_games_path) {
+      setSettingsJsonAvailable(null);
+      return () => {
+        active = false;
+      };
+    }
+    invoke<boolean>("check_saved_games_settings", { path: config.saved_games_path })
+      .then((exists) => {
+        if (active) setSettingsJsonAvailable(exists);
+      })
+      .catch(() => {
+        if (active) setSettingsJsonAvailable(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [open, config?.saved_games_path]);
 
   // Game settings edit states (per account)
   const [selectedAccountId, setSelectedAccountId] = useState<string>("");
@@ -568,6 +589,15 @@ export function SettingsCenter({ open, onClose, onReconfigure, initialTab, initi
                       <Button size="sm" onClick={() => pickFolder("saved_games_path", "存档目录")}>浏览</Button>
                       <Button size="sm" onClick={() => applyDetectedPath("saved_games_path", detectedPaths.savedGames)}>自动探测</Button>
                     </div>
+                    {settingsJsonAvailable === false && (
+                      <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg"
+                        style={{ background: "var(--toast-warning-bg)", border: "1px solid var(--toast-warning-border)" }}>
+                        <ShieldAlert size={14} className="text-warning shrink-0 mt-0.5" />
+                        <p className="text-xs text-text-secondary leading-relaxed">
+                          未检测到 Settings.json。账号创建、登录和多开不受影响，但系统画质读取、账号独立画质配置与覆盖暂不可用。
+                        </p>
+                      </div>
+                    )}
                   </div>
                 </div>
 

--- a/src/pages/SetupWizard.tsx
+++ b/src/pages/SetupWizard.tsx
@@ -32,6 +32,7 @@ export function SetupWizard({ onComplete, initialConfig }: Props) {
   const [currentStep, setCurrentStep] = useState(0);
   const [showError, setShowError] = useState(false);
   const [isCurrentStepValid, setIsCurrentStepValid] = useState(false);
+  const [settingsJsonAvailable, setSettingsJsonAvailable] = useState<boolean | null>(null);
 
   const handleSelectBrowser = async (btype: "chrome" | "edge") => {
     try {
@@ -144,6 +145,26 @@ export function SetupWizard({ onComplete, initialConfig }: Props) {
 
   useEffect(() => {
     let active = true;
+    if (!config.saved_games_path) {
+      setSettingsJsonAvailable(null);
+      return () => {
+        active = false;
+      };
+    }
+    invoke<boolean>("check_saved_games_settings", { path: config.saved_games_path })
+      .then((exists) => {
+        if (active) setSettingsJsonAvailable(exists);
+      })
+      .catch(() => {
+        if (active) setSettingsJsonAvailable(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [config.saved_games_path]);
+
+  useEffect(() => {
+    let active = true;
     const checkStepValidity = async () => {
       const step = steps[currentStep];
       if (!step) return;
@@ -156,6 +177,11 @@ export function SetupWizard({ onComplete, initialConfig }: Props) {
 
       if (!step.value) {
         if (active) setIsCurrentStepValid(false);
+        return;
+      }
+
+      if (step.key === "saved_games_path") {
+        if (active) setIsCurrentStepValid(true);
         return;
       }
 
@@ -284,6 +310,16 @@ export function SetupWizard({ onComplete, initialConfig }: Props) {
             <p className="text-sm text-success mt-3 flex items-center gap-1.5">
               <Check size={11}/> 已自动检测到
             </p>
+          )}
+
+          {current.key === "saved_games_path" && settingsJsonAvailable === false && (
+            <div className="flex items-start gap-2 px-3 py-2.5 rounded-card mt-3"
+              style={{ background: "var(--toast-warning-bg)", border: "1px solid var(--toast-warning-border)" }}>
+              <AlertTriangle size={14} className="text-warning shrink-0 mt-0.5" />
+              <p className="text-xs text-text-secondary leading-relaxed">
+                当前目录中未找到 Settings.json。账号创建、登录和多开不受影响，但画质配置相关功能暂不可用。请先启动一次游戏生成该文件，或稍后在设置中修正存档目录。
+              </p>
+            </div>
           )}
 
           {current.key === "browser_path" && (

--- a/src/visual-audit.tsx
+++ b/src/visual-audit.tsx
@@ -318,6 +318,8 @@ function installIpcMock() {
       case "check_path_exists":
       case "check_bnet_logged_in":
         return true;
+      case "check_saved_games_settings":
+        return false;
       case "get_app_version":
         return "0.7.2";
       case "check_cloud_version":


### PR DESCRIPTION
## 问题
存档目录设置错误或缺少 `Settings.json` 时，当前版本会阻止账号创建或初始化，实际与多开功能无关。

## 修改
- 首次引导和设置中心检测 `Settings.json`，缺失时显示非阻塞提示
- 账号创建和初始化不再强制要求该文件
- 普通登录、多开不受影响；仅在实际应用账号独立画质配置时进行严格检查并提示
- 版本更新至 0.7.6，并补充完整/Lite NSIS 构建脚本
- README 补充该行为的中英文说明

## 验证
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features`（5 passed）
- `npm test`
- `npm run build`
- 首次引导与设置中心警告状态视觉检查
- 完整版和 Lite NSIS 本地构建验证