### PR TITLE
fix(ocr): require a valid target account

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:full:nsis": "cross-env VITE_ENABLE_OCR=true tauri build --bundles nsis",
     "build:lite:nsis": "cross-env VITE_ENABLE_OCR=false tauri build --bundles nsis --config src-tauri/tauri.lite.conf.json -- --no-default-features",
     "build:all": "npm run build:full && npm run build:lite",
-    "test": "node scripts/run-shortcut-tests.cjs",
+    "test": "node scripts/run-tests.cjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/scripts/run-tests.cjs
+++ b/scripts/run-tests.cjs
@@ -15,4 +15,15 @@ require.extensions[".ts"] = function loadTs(module, filename) {
   module._compile(output.outputText, filename);
 };
 
-require(path.join(__dirname, "..", "src", "utils", "shortcut.test.ts"));
+function findTests(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return findTests(fullPath);
+    return entry.name.endsWith(".test.ts") ? [fullPath] : [];
+  });
+}
+
+const sourceDirectory = path.join(__dirname, "..", "src");
+for (const testFile of findTests(sourceDirectory).sort()) {
+  require(testFile);
+}

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -589,19 +589,46 @@ pub fn update_account_meta(
 /// 删除账号
 #[tauri::command]
 pub fn delete_account(
+    app: tauri::AppHandle,
     state: tauri::State<'_, SharedState>,
     account_id: String,
 ) -> Result<(), AppError> {
-    let config = state.config.read();
-    let cfg = config
-        .as_ref()
-        .ok_or_else(|| AppError::ConfigReadError("尚未完成首次配置".to_string()))?;
+    let accounts_dir = {
+        let config = state.config.read();
+        config
+            .as_ref()
+            .ok_or_else(|| AppError::ConfigReadError("尚未完成首次配置".to_string()))?
+            .accounts_dir
+            .clone()
+    };
 
-    let dir = AccountManager::account_dir_checked(&cfg.accounts_dir, &account_id)?;
+    let dir = AccountManager::account_dir_checked(&accounts_dir, &account_id)?;
     if !dir.exists() {
         return Err(AppError::AccountNotFound(account_id));
     }
     std::fs::remove_dir_all(&dir)?;
+
+    let updated_config = {
+        let mut config = state.config.write();
+        let cfg = config
+            .as_mut()
+            .ok_or_else(|| AppError::ConfigReadError("尚未完成首次配置".to_string()))?;
+        if cfg.ocr_target_account.trim() == account_id {
+            cfg.ocr_enabled = false;
+            cfg.ocr_target_account.clear();
+            cfg.save(&state.app_data_dir)?;
+            Some(cfg.clone())
+        } else {
+            None
+        }
+    };
+
+    if let Some(config) = updated_config {
+        #[cfg(feature = "ocr")]
+        crate::ocr::stop_ocr_monitor();
+        let _ = app.emit("global-config-updated", config);
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/commands/global_config.rs
+++ b/src-tauri/src/commands/global_config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+use crate::commands::account::{AccountManager, AccountMeta};
 use crate::error::AppError;
 use crate::state::SharedState;
 
@@ -183,8 +184,9 @@ fn validate_config_paths(config: &GlobalConfig) -> Result<(), AppError> {
 }
 
 #[cfg(test)]
-mod saved_games_validation_tests {
+mod validation_tests {
     use super::{saved_games_settings_exists, validate_config_paths, GlobalConfig};
+    use crate::commands::account::{AccountManager, AccountMeta};
 
     fn temp_dir(name: &str) -> std::path::PathBuf {
         let unique = format!(
@@ -226,6 +228,62 @@ mod saved_games_validation_tests {
 
         assert!(saved_games_settings_exists(&saved_games));
         let _ = std::fs::remove_dir_all(saved_games);
+    }
+
+    #[test]
+    fn enabled_ocr_requires_a_selected_account() {
+        let mut config = GlobalConfig::default();
+        config.ocr_enabled = true;
+
+        assert!(config.resolve_ocr_target_account().is_err());
+    }
+
+    #[test]
+    fn disabled_ocr_does_not_require_a_target_account() {
+        let config = GlobalConfig::default();
+
+        assert!(config.resolve_ocr_target_account().unwrap().is_none());
+    }
+
+    #[test]
+    fn enabled_ocr_requires_an_initialized_account() {
+        let accounts_dir = temp_dir("ocr_uninitialized_account");
+        let account = AccountMeta::new("acount1");
+        AccountManager::save_meta(accounts_dir.to_str().unwrap(), &account).unwrap();
+
+        let mut config = GlobalConfig::default();
+        config.accounts_dir = accounts_dir.to_string_lossy().to_string();
+        config.ocr_enabled = true;
+        config.ocr_target_account = account.id;
+
+        assert!(config.resolve_ocr_target_account().is_err());
+        let _ = std::fs::remove_dir_all(accounts_dir);
+    }
+
+    #[test]
+    fn enabled_ocr_accepts_an_initialized_account() {
+        let accounts_dir = temp_dir("ocr_initialized_account");
+        let mut account = AccountMeta::new("acount1");
+        account.initialized = true;
+        AccountManager::save_meta(accounts_dir.to_str().unwrap(), &account).unwrap();
+
+        let mut config = GlobalConfig::default();
+        config.accounts_dir = accounts_dir.to_string_lossy().to_string();
+        config.ocr_enabled = true;
+        config.ocr_target_account = account.id.clone();
+
+        let resolved = config.resolve_ocr_target_account().unwrap().unwrap();
+        assert_eq!(resolved.id, account.id);
+        let _ = std::fs::remove_dir_all(accounts_dir);
+    }
+
+    #[test]
+    fn invalid_legacy_ocr_configuration_is_disabled() {
+        let mut config = GlobalConfig::default();
+        config.ocr_enabled = true;
+
+        assert!(config.normalize_ocr_configuration());
+        assert!(!config.ocr_enabled);
     }
 }
 
@@ -281,6 +339,41 @@ impl Default for GlobalConfig {
 }
 
 impl GlobalConfig {
+    /// 解析并验证当前 OCR 目标。OCR 关闭时不要求配置目标账号。
+    pub(crate) fn resolve_ocr_target_account(&self) -> Result<Option<AccountMeta>, AppError> {
+        if !self.ocr_enabled {
+            return Ok(None);
+        }
+
+        let account_id = self.ocr_target_account.trim();
+        if account_id.is_empty() {
+            return Err(AppError::ConfigWriteError(
+                "启用 OCR 前请先选择目标账号".to_string(),
+            ));
+        }
+
+        let account = AccountManager::load_meta(&self.accounts_dir, account_id).map_err(|_| {
+            AppError::ConfigWriteError(format!("OCR 目标账号不存在: {account_id}"))
+        })?;
+        if !account.initialized {
+            return Err(AppError::ConfigWriteError(format!(
+                "OCR 目标账号尚未初始化: {account_id}"
+            )));
+        }
+
+        Ok(Some(account))
+    }
+
+    /// 兼容旧配置：无效目标不能保持 OCR 启用状态。
+    fn normalize_ocr_configuration(&mut self) -> bool {
+        if !self.ocr_enabled || self.resolve_ocr_target_account().is_ok() {
+            return false;
+        }
+
+        self.ocr_enabled = false;
+        true
+    }
+
     fn config_path(app_data_dir: &str) -> PathBuf {
         Path::new(app_data_dir).join("global_config.json")
     }
@@ -298,14 +391,28 @@ impl GlobalConfig {
         let content = std::fs::read_to_string(&path)
             .map_err(|e| AppError::ConfigReadError(e.to_string()))?;
         let mut config: GlobalConfig = serde_json::from_str(&content)?;
+        let mut migrated = false;
+
+        let accounts_dir = app_accounts_dir(app_data_dir).to_string_lossy().to_string();
+        if config.accounts_dir != accounts_dir {
+            config.accounts_dir = accounts_dir;
+            migrated = true;
+        }
+
         // 迁移：从未配置过快捷键的旧用户，自动写入默认值
         if config.shortcut_bindings_json.is_empty() {
             config.shortcut_bindings_json =
                 r#"{"1":"Ctrl+1","2":"Ctrl+2","3":"Ctrl+3"}"#.to_string();
-            let _ = config.save(app_data_dir);
+            migrated = true;
         }
         // 迁移：去除旧版本可能存在的 Win/Meta/Cmd 修饰键（v0.6.6 起不再支持）
-        let migrated = Self::strip_win_modifiers(&mut config.shortcut_bindings_json);
+        migrated |= Self::strip_win_modifiers(&mut config.shortcut_bindings_json);
+
+        if config.normalize_ocr_configuration() {
+            log::warn!("检测到无效的旧版 OCR 目标配置，已自动关闭 OCR");
+            migrated = true;
+        }
+
         if migrated {
             let _ = config.save(app_data_dir);
         }
@@ -507,6 +614,7 @@ pub fn save_global_config(
     if cfg.first_run_complete {
         validate_config_paths(&cfg)?;
     }
+    cfg.resolve_ocr_target_account()?;
 
     cfg.save(&state.app_data_dir)?;
     cfg.ensure_dirs()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -382,6 +382,7 @@ pub fn run() {
             commands::terror_zone::get_next_terror_zone,
             // ── OCR 文字检测 ──
             #[cfg(feature = "ocr")] ocr::start_ocr_monitor,
+            #[cfg(feature = "ocr")] ocr::restart_ocr_monitor,
             #[cfg(feature = "ocr")] ocr::stop_ocr_monitor,
             #[cfg(feature = "ocr")] ocr::get_ocr_ch_a_results,
             #[cfg(feature = "ocr")] ocr::get_ocr_ch_b_results,

--- a/src-tauri/src/ocr/mod.rs
+++ b/src-tauri/src/ocr/mod.rs
@@ -5,43 +5,62 @@ pub mod pipeline;
 pub mod fuzzy;
 pub mod game_data;
 
+use crate::commands::account::AccountMeta;
+use crate::commands::global_config::GlobalConfig;
+use pipeline::OcrMonitor;
+use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
-use serde::{Deserialize, Serialize};
 use tauri::Manager;
-use pipeline::OcrMonitor;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct OcrConfig {
     pub window_title: String,
     /// 目标游戏进程 PID（优先于 window_title，用于精确定位窗口）
-    #[serde(default)]
     pub target_pid: Option<u32>,
-    #[serde(default = "default_poll_interval")]
     pub poll_interval_ms: u64,
-    #[serde(default = "default_debug_output")]
     pub debug_output: bool,
-    #[serde(default = "default_text_matcher_threshold")]
     pub text_matcher_threshold: u8,
-    #[serde(default = "default_rune_matcher_threshold")]
     pub rune_matcher_threshold: u8,
-    #[serde(default)]
     pub use_cuda: bool,
-    #[serde(default = "default_scene_text_color_rgb")]
     pub scene_text_color_rgb: [u8; 3],
-    #[serde(default = "default_scene_text_color_range")]
     pub scene_text_color_range: [u8; 3],
-    #[serde(default = "default_rune_text_color_rgb")]
     pub rune_text_color_rgb: [u8; 3],
-    #[serde(default = "default_rune_text_color_range")]
     pub rune_text_color_range: [u8; 3],
-    #[serde(alias = "rune_blackground_color_rgb", default = "default_rune_background_color_rgb")]
     pub rune_background_color_rgb: [u8; 3],
-    #[serde(alias = "rune_blackground_color_range", default = "default_rune_background_color_range")]
     pub rune_background_color_range: [u8; 3],
 }
-fn default_poll_interval() -> u64 { 500 }
-fn default_debug_output() -> bool { false }
+
+impl OcrConfig {
+    fn from_account(
+        global_config: &GlobalConfig,
+        account: &AccountMeta,
+        target_pid: Option<u32>,
+    ) -> Self {
+        let window_title = if account.display_name.trim().is_empty() {
+            account.id.clone()
+        } else {
+            account.display_name.clone()
+        };
+
+        Self {
+            window_title,
+            target_pid,
+            poll_interval_ms: global_config.ocr_poll_interval_ms,
+            debug_output: global_config.ocr_debug_output,
+            text_matcher_threshold: default_text_matcher_threshold(),
+            rune_matcher_threshold: default_rune_matcher_threshold(),
+            use_cuda: false,
+            scene_text_color_rgb: default_scene_text_color_rgb(),
+            scene_text_color_range: default_scene_text_color_range(),
+            rune_text_color_rgb: default_rune_text_color_rgb(),
+            rune_text_color_range: default_rune_text_color_range(),
+            rune_background_color_rgb: default_rune_background_color_rgb(),
+            rune_background_color_range: default_rune_background_color_range(),
+        }
+    }
+}
+
 fn default_text_matcher_threshold() -> u8 { 67 }
 fn default_rune_matcher_threshold() -> u8 { 67 }
 fn default_scene_text_color_rgb() -> [u8; 3] { [202, 23, 0] }
@@ -72,6 +91,36 @@ static CH_A_RESULTS: std::sync::OnceLock<Mutex<Vec<OcrTextItem>>> = std::sync::O
 static CH_B_RESULTS: std::sync::OnceLock<Mutex<Vec<OcrTextItem>>> = std::sync::OnceLock::new();
 static MONITOR: std::sync::OnceLock<Mutex<Option<OcrMonitor>>> = std::sync::OnceLock::new();
 static RUNNING: AtomicBool = AtomicBool::new(false);
+static GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn resolve_monitor_config(app: &tauri::AppHandle) -> Result<OcrConfig, String> {
+    let state = app.state::<crate::state::SharedState>();
+    let (global_config, account) = {
+        let config = state.config.read();
+        let global_config = config
+            .as_ref()
+            .ok_or_else(|| "尚未完成首次配置".to_string())?;
+        let account = global_config
+            .resolve_ocr_target_account()
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "OCR 尚未启用".to_string())?;
+        (global_config.clone(), account)
+    };
+    let target_pid = state
+        .active_games
+        .read()
+        .get(&account.id)
+        .copied()
+        .or(account.running_pid);
+
+    Ok(OcrConfig::from_account(&global_config, &account, target_pid))
+}
+
+fn mark_generation_stopped(generation: u64) {
+    if GENERATION.load(Ordering::SeqCst) == generation {
+        RUNNING.store(false, Ordering::SeqCst);
+    }
+}
 
 fn install_ocr_worker_panic_hook(debug_dir_for_panic: Option<std::path::PathBuf>) {
     std::panic::set_hook(Box::new(move |info| {
@@ -120,7 +169,8 @@ pub fn get_ocr_ch_b_results() -> Vec<OcrTextItem> {
 
 /// 启动 OCR 轮询 (2Hz)
 #[tauri::command]
-pub fn start_ocr_monitor(app: tauri::AppHandle, config: OcrConfig) -> Result<(), String> {
+pub fn start_ocr_monitor(app: tauri::AppHandle) -> Result<(), String> {
+    let config = resolve_monitor_config(&app)?;
     if RUNNING.swap(true, Ordering::SeqCst) {
         return Err("OCR 监控器已在运行中".to_string());
     }
@@ -162,7 +212,6 @@ pub fn start_ocr_monitor(app: tauri::AppHandle, config: OcrConfig) -> Result<(),
     let is_debug = config.debug_output;
     let use_cuda = config.use_cuda;
 
-    static GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let my_gen = GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
 
     std::thread::Builder::new().name("ocr-worker".into()).spawn(move || {
@@ -187,7 +236,7 @@ pub fn start_ocr_monitor(app: tauri::AppHandle, config: OcrConfig) -> Result<(),
         let resource_dir = app.path().resource_dir().ok();
         if let Err(e) = engine::init_engine(&app_data_dir, resource_dir.as_deref(), use_cuda) {
             eprintln!("[OCR Error] Failed to init engine on worker thread: {}", e);
-            RUNNING.store(false, Ordering::SeqCst);
+            mark_generation_stopped(my_gen);
             unsafe { windows::Win32::System::Com::CoUninitialize(); }
             return;
         }
@@ -215,7 +264,7 @@ pub fn start_ocr_monitor(app: tauri::AppHandle, config: OcrConfig) -> Result<(),
                     Ok(false) => { break; }
                     Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                         eprintln!("[OCR Error] OCR poll timeout ({}ms). Worker thread may be deadlocked.", timeout_ms);
-                        RUNNING.store(false, Ordering::SeqCst);
+                        mark_generation_stopped(my_gen);
                         break;
                     }
                     Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
@@ -280,14 +329,17 @@ pub fn start_ocr_monitor(app: tauri::AppHandle, config: OcrConfig) -> Result<(),
         }
 
         let _ = watchdog_tx.send(false);
-        RUNNING.store(false, Ordering::SeqCst);
+        mark_generation_stopped(my_gen);
         eprintln!("[OCR Info] Worker thread exited");
 
         // Clean up COM runtime before thread exit
         unsafe {
             windows::Win32::System::Com::CoUninitialize();
         }
-    }).map_err(|e| format!("创建工作线程失败: {}", e))?;
+    }).map_err(|e| {
+        mark_generation_stopped(my_gen);
+        format!("创建工作线程失败: {}", e)
+    })?;
 
     Ok(())
 }
@@ -295,8 +347,16 @@ pub fn start_ocr_monitor(app: tauri::AppHandle, config: OcrConfig) -> Result<(),
 /// 停止 OCR 轮询
 #[tauri::command]
 pub fn stop_ocr_monitor() {
+    GENERATION.fetch_add(1, Ordering::SeqCst);
     RUNNING.store(false, Ordering::SeqCst);
     if let Some(lock) = MONITOR.get() {
         *lock.lock().unwrap_or_else(|e| e.into_inner()) = None;
     }
+}
+
+/// 使用已保存的全局配置原子地重启 OCR。
+#[tauri::command]
+pub fn restart_ocr_monitor(app: tauri::AppHandle) -> Result<(), String> {
+    stop_ocr_monitor();
+    start_ocr_monitor(app)
 }

--- a/src/components/config/SettingsCenter.tsx
+++ b/src/components/config/SettingsCenter.tsx
@@ -33,6 +33,7 @@ import {
   SettingsMap
 } from "../../pages/SettingsEditor";
 import type { GlobalConfig } from "../../store/types";
+import { validateOcrTarget } from "../../utils/ocrTarget";
 
 // Helper for quadratic opacity mapping
 // Map slider value s (0..100) to stored percentage p (10..100)
@@ -68,6 +69,8 @@ export function SettingsCenter({ open, onClose, onReconfigure, initialTab, initi
   const { config, save, detectBattleNetPath, detectSavedGamesPath, detectProgramDataAgentPath, detectAppDataRoamingBnetPath, detectBrowserPath } = useGlobalConfig();
   const { accounts, loadAccounts, renameAccount, updateAccountMods, repairAllRegistries } = useAccounts();
   const { theme, setTheme } = useTheme();
+  const initializedOcrAccounts = accounts.filter((account) => account.initialized);
+  const ocrTarget = validateOcrTarget(config?.ocr_target_account ?? "", accounts);
 
   // Tab and search state
   const [activeTab, setActiveTab] = useState<TabType>("accounts");
@@ -1192,29 +1195,49 @@ export function SettingsCenter({ open, onClose, onReconfigure, initialTab, initi
                       <p className="text-2xs text-text-muted">识别所有场景地点与符文掉落，#24 以上高级符文额外截图保存</p>
                     </div>
                     <Toggle
-                      checked={!!config.ocr_enabled}
+                      checked={!!config.ocr_enabled && ocrTarget.valid}
+                      disabled={!ocrTarget.valid}
+                      ariaLabel="启用场景符文自动识别"
+                      descriptionId="ocr-target-help"
                       onChange={v => updateConfig(c => { c.ocr_enabled = v; })}
                     />
                   </div>
 
-                  {config.ocr_enabled && (
-                    <div className="space-y-3 border-t border-border-default/50 pt-3">
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <span className="text-sm font-semibold text-text-secondary">识别目标账号</span>
-                          <p className="text-2xs text-text-muted">哪个游戏账号对应哪一个窗口将接受 OCR 检测</p>
-                        </div>
-                        <select
-                          value={config.ocr_target_account || ""}
-                          onChange={e => updateConfig(c => { c.ocr_target_account = e.target.value; })}
-                          className="h-8 px-2.5 rounded-lg bg-surface-hover border border-border-default text-text-primary text-xs"
-                        >
-                          <option value="">当前聚焦窗口</option>
-                          {accounts.filter(a => a.initialized).map(a => (
-                            <option key={a.id} value={a.id}>{a.display_name || a.id}</option>
-                          ))}
-                        </select>
+                  <div className="space-y-1.5 border-t border-border-default/50 pt-3">
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <label htmlFor="ocr-target-account" className="text-sm font-semibold text-text-secondary">
+                          识别目标账号
+                        </label>
+                        <p className="text-2xs text-text-muted">选择一个已初始化账号作为固定 OCR 识别窗口</p>
                       </div>
+                      <select
+                        id="ocr-target-account"
+                        value={ocrTarget.valid ? ocrTarget.account.id : ""}
+                        disabled={initializedOcrAccounts.length === 0}
+                        aria-describedby="ocr-target-help"
+                        onChange={e => updateConfig(c => { c.ocr_target_account = e.target.value; })}
+                        className="h-8 min-w-36 px-2.5 rounded-lg bg-surface-hover border border-border-default text-text-primary text-xs disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        <option value="" disabled>
+                          {initializedOcrAccounts.length === 0 ? "暂无可用账号" : "请选择账号"}
+                        </option>
+                        {initializedOcrAccounts.map(account => (
+                          <option key={account.id} value={account.id}>{account.display_name || account.id}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <p id="ocr-target-help" aria-live="polite" className="text-2xs text-text-secondary">
+                      {initializedOcrAccounts.length === 0
+                        ? "请先初始化至少一个账号，才能启用 OCR。"
+                        : ocrTarget.valid
+                          ? `OCR 将固定监测“${ocrTarget.account.display_name || ocrTarget.account.id}”的游戏窗口。`
+                          : "请先选择目标账号，才能启用 OCR。"}
+                    </p>
+                  </div>
+
+                  {config.ocr_enabled && ocrTarget.valid && (
+                    <div className="space-y-3 border-t border-border-default/50 pt-3">
 
                       <div className="flex items-center justify-between">
                         <div>
@@ -1247,38 +1270,31 @@ export function SettingsCenter({ open, onClose, onReconfigure, initialTab, initi
 
                       {/* Restart OCR button */}
                       <div className="border-t border-border-default/50 pt-3">
-                        <button
+                        <Button
+                          variant="secondary"
+                          size="md"
                           onClick={async () => {
                             try {
-                              await invoke("stop_ocr_monitor").catch(() => {});
-                              const targetAccount = accounts.find(a => a.id === config.ocr_target_account);
-                              const winTitle = targetAccount?.display_name || config.ocr_target_account || "";
-                              const targetPid = targetAccount?.running_pid ?? null;
-                              await invoke("start_ocr_monitor", {
-                                config: {
-                                  window_title: winTitle,
-                                  target_pid: targetPid,
-                                  poll_interval_ms: config.ocr_poll_interval_ms ?? 500,
-                                  debug_output: config.ocr_debug_output ?? false,
-                                },
-                              });
+                              await save(config);
+                              setOriginalConfig(JSON.parse(JSON.stringify(config)));
+                              await invoke("restart_ocr_monitor");
                               showToast("success", "OCR 已用新配置重启");
                             } catch (e) {
                               showToast("error", "重启 OCR 失败: " + e);
                             }
                           }}
-                          className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-md font-medium text-accent bg-accent/10 hover:bg-accent/20 transition-all duration-150"
+                          className="w-full"
                         >
                           <RotateCw size={13} className="shrink-0" />
                           应用配置并重启 OCR
-                        </button>
+                        </Button>
                         <p className="text-2xs text-text-muted text-center mt-1">使用当前参数重新启动 OCR 识别</p>
                       </div>
                     </div>
                   )}
                 </div>
 
-                {config.ocr_enabled && (
+                {config.ocr_enabled && ocrTarget.valid && (
                   <div className="spatial-panel p-4 space-y-2">
                     <span className="text-xs font-bold text-text-primary block mb-1">OCR 统计结果</span>
                     <p className="text-2xs text-text-muted">查看当前数据库内的符文掉落与统计信息</p>

--- a/src/components/config/tabs/OcrTab.tsx
+++ b/src/components/config/tabs/OcrTab.tsx
@@ -4,12 +4,16 @@ import { useGlobalConfig } from "../../../store/globalConfig";
 import { useAccounts } from "../../../store/accounts";
 import { showToast } from "../../ui/Toast";
 import { Toggle } from "../../ui/Toggle";
+import { validateOcrTarget } from "../../../utils/ocrTarget";
 
 export function OcrTab() {
   const { config, save } = useGlobalConfig();
   const { accounts } = useAccounts();
 
   if (!config) return null;
+
+  const initializedAccounts = accounts.filter((account) => account.initialized);
+  const ocrTarget = validateOcrTarget(config.ocr_target_account, accounts);
 
   return (
     <div className="space-y-4">
@@ -18,6 +22,10 @@ export function OcrTab() {
       {/* Enable toggle */}
       <div
         onClick={async () => {
+          if (!config.ocr_enabled && !ocrTarget.valid) {
+            showToast("warning", "请先选择 OCR 目标账号");
+            return;
+          }
           await save({ ...config, ocr_enabled: !config.ocr_enabled });
         }}
         className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-md
@@ -30,7 +38,12 @@ export function OcrTab() {
           <p className="text-xs text-text-muted mt-0.5">游戏启动后自动开始 OCR 文字识别</p>
         </div>
         <div className="shrink-0 mr-1 pointer-events-none">
-          <Toggle checked={config.ocr_enabled} onChange={() => {}} />
+          <Toggle
+            checked={config.ocr_enabled && ocrTarget.valid}
+            disabled={!ocrTarget.valid}
+            ariaLabel="启用自动文字识别"
+            onChange={() => {}}
+          />
         </div>
       </div>
 
@@ -57,15 +70,16 @@ export function OcrTab() {
       <div className="space-y-1.5">
         <span className="text-xs text-text-muted font-medium">识别对象（游戏窗口）</span>
         <select
-          value={config.ocr_target_account}
+          value={ocrTarget.valid ? ocrTarget.account.id : ""}
+          disabled={initializedAccounts.length === 0}
           onChange={async (e) => {
             await save({ ...config, ocr_target_account: e.target.value });
           }}
           className="w-full h-8 px-2.5 rounded-lg text-md text-text-primary focus:outline-none focus:ring-1 focus:ring-accent/40"
           style={{ background: 'var(--surface-base)', border: '1px solid var(--border-default)' }}
         >
-          <option value="">-- 选择账号 --</option>
-          {accounts.filter(a => a.initialized).map(a => (
+          <option value="" disabled>{initializedAccounts.length === 0 ? "-- 暂无可用账号 --" : "-- 选择账号 --"}</option>
+          {initializedAccounts.map(a => (
             <option key={a.id} value={a.id}>{a.display_name || a.id} ({a.id})</option>
           ))}
         </select>
@@ -93,22 +107,14 @@ export function OcrTab() {
       </div>
 
       {/* Restart OCR */}
-      <button onClick={async () => {
+      <button disabled={!config.ocr_enabled || !ocrTarget.valid} onClick={async () => {
           try {
-            await invoke("stop_ocr_monitor").catch(()=>{});
-            const targetAccount = accounts.find(a => a.id === config.ocr_target_account);
-            const winTitle = targetAccount?.display_name || config.ocr_target_account || "";
-            const targetPid = targetAccount?.running_pid ?? null;
-            await invoke("start_ocr_monitor", { config: {
-              window_title: winTitle,
-              target_pid: targetPid,
-              poll_interval_ms: config.ocr_poll_interval_ms ?? 500,
-              debug_output: config.ocr_debug_output ?? false,
-            }});
+            await save(config);
+            await invoke("restart_ocr_monitor");
             showToast("success", "OCR 已用新配置重启");
           } catch(e) { showToast("error","重启OCR失败: "+e); }
         }}
-        className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-md text-accent hover:bg-accent/10 transition-all duration-150 text-left">
+        className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-md text-accent hover:bg-accent/10 transition-all duration-150 text-left disabled:opacity-50 disabled:cursor-not-allowed">
         <RefreshCw size={13} className="shrink-0" />
         <div>
           <p className="font-medium">应用配置并重启 OCR</p>

--- a/src/components/ui/Toggle.tsx
+++ b/src/components/ui/Toggle.tsx
@@ -3,6 +3,8 @@ interface ToggleProps {
   onChange: (checked: boolean) => void;
   disabled?: boolean;
   label?: string;
+  ariaLabel?: string;
+  descriptionId?: string;
 }
 
 export function Toggle({
@@ -10,6 +12,8 @@ export function Toggle({
   onChange,
   disabled = false,
   label,
+  ariaLabel,
+  descriptionId,
 }: ToggleProps) {
   return (
     <label
@@ -23,7 +27,8 @@ export function Toggle({
       <button
         role="switch"
         aria-checked={checked}
-        aria-label={label || (checked ? "关闭开关" : "开启开关")}
+        aria-label={ariaLabel || label || (checked ? "关闭开关" : "开启开关")}
+        aria-describedby={descriptionId}
         disabled={disabled}
         onClick={() => !disabled && onChange(!checked)}
         className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full

--- a/src/hooks/useAppEffects.ts
+++ b/src/hooks/useAppEffects.ts
@@ -7,6 +7,7 @@ import { useAccounts } from "../store/accounts";
 import { useGlobalConfig } from "../store/globalConfig";
 import { showToast } from "../components/ui/Toast";
 import type { GlobalConfig, LaunchProgress } from "../store/types";
+import { validateOcrTarget } from "../utils/ocrTarget";
 
 export function useBongoCatWindow(loading: boolean, config: GlobalConfig | null) {
   const prevEnabledRef = useRef(config?.enable_bongo_cat);
@@ -167,25 +168,17 @@ export function useLaunchEvents(config: GlobalConfig | null) {
     prevLaunchingRef.current = launching;
     if (!wasLaunching || launching || !config) return;
     if (import.meta.env.VITE_ENABLE_OCR === "false") return;
-    if (!config.ocr_enabled || !config.ocr_target_account) return;
+    if (!config.ocr_enabled) return;
 
-    const targetResult = results.find(r => r.account_id === config.ocr_target_account);
+    const target = validateOcrTarget(config.ocr_target_account, accounts);
+    if (!target.valid) return;
+
+    const targetResult = results.find(r => r.account_id === target.account.id);
     if (!targetResult || !targetResult.success) return;
-
-    const targetAccount = accounts.find(a => a.id === config.ocr_target_account);
-    const winTitle = targetAccount?.display_name || config.ocr_target_account;
-    const targetPid = targetAccount?.running_pid ?? null;
 
     const timer = setTimeout(async () => {
       try {
-        await invoke("start_ocr_monitor", {
-          config: {
-            window_title: winTitle,
-            target_pid: targetPid,
-            poll_interval_ms: config.ocr_poll_interval_ms ?? 500,
-            debug_output: config.ocr_debug_output ?? false,
-          }
-        });
+        await invoke("start_ocr_monitor");
         showToast("success", "OCR 监控已自动启动");
       } catch (e) {
         showToast("error", `OCR 启动失败: ${e}`);

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -182,7 +182,6 @@ const textMap: Record<string, string> = {
   "识别所有场景地点与符文掉落，#24 以上高级符文额外截图保存": "Recognize scene locations and rune drops. Runes #24+ save extra screenshots.",
   "识别目标账号": "OCR Target Account",
   "哪个游戏账号对应哪一个窗口将接受 OCR 检测": "Choose which account/window receives OCR detection",
-  "当前聚焦窗口": "Current Focused Window",
   "OCR 帧采样轮询间隔 (ms)": "OCR Frame Poll Interval (ms)",
   "两次屏幕截取分析的时间差，设置过小可能消耗较高 CPU": "Interval between screen captures. Lower values may use more CPU.",
   "高刷新-高负荷": "high refresh / high load",

--- a/src/utils/ocrTarget.test.ts
+++ b/src/utils/ocrTarget.test.ts
@@ -1,0 +1,53 @@
+import type { AccountMeta } from "../store/types";
+import { validateOcrTarget } from "./ocrTarget";
+
+function account(overrides: Partial<AccountMeta> = {}): AccountMeta {
+  return {
+    id: "acount1",
+    display_name: "Ladder Sorc",
+    mod_args: "",
+    created_at: "2026-08-10T00:00:00Z",
+    last_launched_at: null,
+    last_reset_at: null,
+    initialized: true,
+    order: 0,
+    is_running: false,
+    ...overrides,
+  };
+}
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(`FAIL: ${message}`);
+  console.log(`PASS: ${message}`);
+}
+
+export function runTests() {
+  const initialized = account();
+  const uninitialized = account({ id: "acount2", initialized: false });
+  const accounts = [initialized, uninitialized];
+
+  const missing = validateOcrTarget("", accounts);
+  assert(!missing.valid && missing.reason === "missing", "OCR requires a selected account");
+
+  const unknown = validateOcrTarget("missing-account", accounts);
+  assert(!unknown.valid && unknown.reason === "not_found", "OCR rejects an unknown account");
+
+  const notInitialized = validateOcrTarget("acount2", accounts);
+  assert(
+    !notInitialized.valid && notInitialized.reason === "not_initialized",
+    "OCR rejects an uninitialized account",
+  );
+
+  const valid = validateOcrTarget("acount1", accounts);
+  assert(valid.valid && valid.account === initialized, "OCR accepts the selected initialized account");
+}
+
+const g = globalThis as any;
+if (typeof g.process !== "undefined" && typeof g.process.argv !== "undefined") {
+  try {
+    runTests();
+  } catch (error) {
+    console.error(error);
+    g.process.exit(1);
+  }
+}

--- a/src/utils/ocrTarget.ts
+++ b/src/utils/ocrTarget.ts
@@ -1,0 +1,19 @@
+import type { AccountMeta } from "../store/types";
+
+export type OcrTargetValidation =
+  | { valid: true; account: AccountMeta }
+  | { valid: false; reason: "missing" | "not_found" | "not_initialized" };
+
+export function validateOcrTarget(
+  accountId: string,
+  accounts: AccountMeta[],
+): OcrTargetValidation {
+  const normalizedId = accountId.trim();
+  if (!normalizedId) return { valid: false, reason: "missing" };
+
+  const account = accounts.find((candidate) => candidate.id === normalizedId);
+  if (!account) return { valid: false, reason: "not_found" };
+  if (!account.initialized) return { valid: false, reason: "not_initialized" };
+
+  return { valid: true, account };
+}


### PR DESCRIPTION
## Summary
- remove the non-functional current-focused-window OCR target and keep target selection visible before enablement
- enforce `ocr_enabled => initialized target account` in both the UI and Rust configuration layer, including legacy-config normalization and account-deletion cleanup
- centralize OCR window/PID resolution in the backend and add an atomic restart command with generation-safe worker shutdown
- extend the TypeScript test runner and add OCR target regression coverage

## Validation
- `npm test`
- `npm run build`
- `cargo test --lib` (25 passed)
- `cargo check --no-default-features`
- `cargo clippy --lib --no-deps -j 1` (completed; 54 pre-existing warnings, none introduced by this change)
- `git diff --check`

## UI verification
- verified disabled, missing-target, selected-target, and enabled-state markup and accessibility relationships statically
- the local visual-audit surface started successfully, but no browser binding was available in this agent session, so screenshot-based QA could not be captured