### PR TITLE
chore(release): prepare v0.7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d2rhub",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d2rhub",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d2rhub",
   "private": true,
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Windows multi-account manager and OCR run tracker for Diablo II: Resurrected",
   "license": "MIT",
   "repository": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "d2rhub"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d2rhub"
-version = "0.7.6"
+version = "0.7.7"
 description = "Diablo II Resurrected Multi-Account Manager"
 authors = ["D2RHub"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
     "productName": "D2RHub",
-    "version": "0.7.6",
+    "version": "0.7.7",
     "identifier": "com.d2rhub.app",
     "build": {
         "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- bump the npm package and lock metadata to 0.7.7
- bump the Rust crate and lock metadata to 0.7.7
- bump the Tauri application version to 0.7.7

## Validation

- npm test
- npm run build
- cargo test --lib (25 passed)
- npm run build:full:nsis
- npm run build:lite:nsis

## Release plan

After merge, rebuild both installers from the release commit, tag it as v0.7.7, and publish the Full and Lite NSIS assets.