### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d2rhub",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d2rhub",
-      "version": "0.7.7",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d2rhub",
   "private": true,
-  "version": "0.7.7",
+  "version": "0.8.0",
   "description": "Windows multi-account manager and OCR run tracker for Diablo II: Resurrected",
   "license": "MIT",
   "repository": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "d2rhub"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d2rhub"
-version = "0.7.7"
+version = "0.8.0"
 description = "Diablo II Resurrected Multi-Account Manager"
 authors = ["D2RHub"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
     "productName": "D2RHub",
-    "version": "0.7.7",
+    "version": "0.8.0",
     "identifier": "com.d2rhub.app",
     "build": {
         "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- bump the npm package and lock metadata from 0.7.7 to 0.8.0
- bump the Rust crate and lock metadata from 0.7.7 to 0.8.0
- bump the Tauri application version from 0.7.7 to 0.8.0
- prepare the release following the edition-aware workspace merge in #7

## Validation

- `npm test` — all frontend tests passed
- `npm run build` — TypeScript and Vite production build passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib -j 1` — 103 passed
- `npm run build:full:nsis` — Full NSIS package created
- `npm run build:lite:nsis` — Lite NSIS package created

## Release content

The GitHub Release will follow the existing Chinese release-note structure and cover:

- explicit CN/global installation isolation and safe legacy migration
- transactional account, registry, Battle.net, browser-profile, and Settings operations
- complete batch launch preflight and bounded account-initialization cancellation
- consolidated settings workspace and clearer recovery states
- OCR/runtime reliability improvements
- adaptive 18px/36px mini overlay layout
- Full and Lite download descriptions plus SHA-256 checksums

## Release plan

After this PR passes the protected `verify` check and is merged:

1. update local `main` to the merge commit
2. rebuild Full and Lite NSIS installers from that exact commit
3. verify installer size and SHA-256
4. create tag `v0.8.0` and publish `Release v0.8.0`
5. upload `D2RHub_0.8.0_x64-setup.exe` and `D2RHub.Lite_0.8.0_x64-setup.exe`
6. verify the published release metadata and asset digests
