### PR TITLE
feat: 改进悬浮窗贴边交互与统计体验

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,143 @@
 <div align="center">
-  <img src="logo.png" alt="D2RHub Logo" width="120" />
+  <img src="logo.png" alt="D2RHub Logo" width="112" />
   <h1>D2RHub</h1>
-  <p><strong>《暗黑破坏神 II：重制版》多账号多开管理器与 OCR 刷图助手 | Diablo II: Resurrected Multi-Account Manager & OCR Run Tracker</strong></p>
+  <p><strong>Diablo II: Resurrected 多账号、多版本与 OCR 刷图助手</strong></p>
   <p>
-    <img src="https://img.shields.io/badge/platform-Windows_10%2F11-blue" alt="Platform" />
-    <img src="https://img.shields.io/badge/no_memory_injection-local_tool-green" alt="Local Tool" />
-    <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="License" />
+    <img src="https://img.shields.io/badge/version-0.8.0-d5a85a" alt="Version 0.8.0" />
+    <img src="https://img.shields.io/badge/platform-Windows_10%2F11-blue" alt="Windows 10/11" />
+    <img src="https://img.shields.io/badge/game_memory-no_injection-2f855a" alt="No game-memory injection" />
+    <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License" />
   </p>
 </div>
 
 ---
 
-## 🇨🇳 中文说明
+## 中文
 
-D2RHub 是一款专为《暗黑破坏神 II：重制版》(D2R) 玩家精心设计的**多账号管理与一键多开及 OCR 辅助助手**。无论是多账号挂机、装备倒腾、多角色配置管理，还是刷图效率统计，它都能让您的游戏体验变得无比轻松和高效。
+D2RHub 是一款 Windows 本地工具，用于管理《暗黑破坏神 II：重制版》的多个账号、国服/国际服客户端配置和多开流程。Full 版还包含屏幕 OCR、场景计时、符文掉落记录与本地统计分析。
 
-### ✨ 核心特色功能
-*   **🎮 本地多开管理**：一键清除游戏的多开限制。基于 Windows 标准进程句柄清理技术，不修改游戏文件，不注入内存或 DLL。
-*   **🚀 账号独立配置**：支持为每个账号绑定独立的战网 Token 实现自动排队登录，支持独立启动参数（Mod 启动）以及独立的单机存档目录。
-*   **⚙️ 图形化画质设置**：内置画质编辑器，支持一键切换画质预设（如小号极低画质、大号超高画质），降低多开时的硬件负载。存档目录缺少 `Settings.json` 时，账号创建、登录和多开仍可正常使用，仅画质配置相关功能暂不可用。
-*   **📊 硬件负载监控**：实时监控 CPU、内存、GPU 及显存占用，多开时硬件状态一目了然。
-*   **🪟 迷你悬浮窗 (Overlay)**：可置顶悬浮在桌面上，支持展开与迷你两种布局。展开模式下双击空白处、迷你模式下双击悬浮窗或聚焦后按 Enter/空格即可切换；两种布局会分别记住窗口尺寸。迷你窗口压缩到 36px 高时会自动改为单行，并可继续缩小到 18px；重新拉高到 36px 时恢复双行。展开模式下双击账号可聚焦对应游戏窗口。
-*   **⏱️ OCR 智能刷图统计**：通过实时 OCR 分析游戏画面，自动记录刷图时间、历史平均用时、总场次等统计数据。
-*   **💎 符文掉落自动记录**：自动匹配游戏内掉落的符文并记录，提供可视化数据分析。
-*   **🐱 桌面键盘猫咪 (Bongo Cat)**：可爱的桌面键盘同步互动猫咪，支持自定义皮肤和按键响应。
+### 当前版本能力
 
-### 🛠️ 快速上手步骤
-1.  **下载软件**：前往 [Releases 页面](https://github.com/gjy991229/D2RHub/releases) 下载最新的版本。
-    *   *安装包版（推荐）*：下载 Release 中的 `.msi` 或 NSIS `.exe` 安装包，双击安装即可。
-2.  **首次运行配置**：启动 D2RHub，设置向导会自动扫描并帮您填写好战网客户端路径、游戏目录以及存档路径，确认无误后点击"保存并继续"。
-3.  **添加与启动账号**：
-    *   点击主界面的"添加账号"，输入您的账号别名。
-    *   点击"初始化"，软件会自动关联您当前的战网和游戏配置。
-    *   勾选想要启动的账号，点击"一键启动"，软件就会帮您自动排队登录并清除多开限制！
+- **国服 / 国际服双版本隔离**：分别配置游戏、存档和 Battle.net 路径；亚服、美服、欧服共用国际服档案。
+- **两种账号认证**：网页 Token 直启，或 Battle.net 客户端认证与本地运行快照；Token 使用 Windows DPAPI 加密保存。
+- **多账号启动控制**：单账号、启动全部、多选启动、取消队列、运行状态与启动日志；支持账号排序、Mod 参数和窗口位置。
+- **账号独立游戏配置**：图形化编辑显示、图形、音频、玩法和地图设置，可在系统配置与账号快照之间切换。
+- **性能悬浮窗**：展开 / 迷你布局分别记忆尺寸；显示账号状态、OCR 场景计时、符文和邪恶区域信息。拖到四边后自动吸附隐藏，悬停平滑抽出、移开再次隐藏。
+- **高 DPI 迷你布局**：双层最低 36 逻辑像素，压缩后切换单行并可缩至 18；适配 2K 与 Windows 缩放。
+- **OCR 与本地统计（Full）**：识别场景和 1–33 号符文，#24 以上保存截图；提供统一筛选、效率分位数、趋势、场景/角色对比、星期×小时热力图、33 号符文图谱、高符命中率与间隔、截图画廊、记录管理和 CSV / JSON 导出。
+- **快捷键与桌宠**：按账号位置聚焦游戏窗口；Bongo Cat 响应键鼠输入，支持缩放、气泡和可解锁皮肤。
 
-### 🛡️ 安全说明
-D2RHub 本质上是一个本地配置、进程与窗口管理器。它通过 Windows 系统 API 关闭 D2R.exe 的单实例检测句柄，**不修改游戏文件、不写入游戏内存、不注入 DLL**。但任何第三方工具都可能受游戏服务条款、杀毒软件误报、系统权限和账号风控策略影响；请自行评估风险并保管好账号凭据。
+### Full 与 Lite
 
-### 🔐 数据与隐私
-D2RHub 的账号配置、Token 加密数据、注册表快照、日志、OCR 调试截图和本地统计数据库均保存在本机，不会主动上传账号配置或 Token。程序会访问 Battle.net 登录页面、GitHub Releases 更新接口和恐怖地带信息接口；启用 OCR 调试输出时，程序可能在本地保存游戏截图裁剪图用于排查识别问题。不需要调试时建议关闭该选项并定期清理本地数据。
+| 功能 | Full | Lite |
+| --- | :---: | :---: |
+| 账号管理、双版本配置、多开 | ✓ | ✓ |
+| 网页 Token / Battle.net 认证 | ✓ | ✓ |
+| 画质编辑、悬浮窗、快捷键、桌宠 | ✓ | ✓ |
+| 场景/符文 OCR、截图与统计页 | ✓ | — |
 
-### 🧑‍💻 从源码开发
-开发环境、常用命令、项目结构和 Windows 构建说明见 [开发指南](docs/DEVELOPMENT.md)。提交修改前请阅读 [贡献指南](CONTRIBUTING.md)。
+### 快速开始
 
-### ⚖️ 许可与第三方声明
-项目有权许可的源码与原创素材采用 [MIT License](LICENSE)。PaddleOCR 模型、第三方依赖和第三方商标继续适用各自的许可或权利声明，详见 [第三方声明](THIRD_PARTY_NOTICES.md)。
+1. 从 [Releases](https://github.com/gjy991229/D2RHub/releases) 下载 Full 或 Lite 的 MSI / NSIS 安装包。
+2. 首次运行时至少完整配置一套“游戏目录 + 存档目录”。Battle.net.exe 只在战网客户端认证时必需；游戏和战网路径需要手动确认，存档、Agent、Roaming 和 Edge/Chrome 支持自动探测。
+3. 点击“添加账号”，按向导设置昵称、区服、界面/配音语言和认证模式。网页 Token 按指引获取并粘贴；战网认证按提示完成客户端登录与初始化。
+4. 从账号卡片启动单个账号，或使用“启动全部 / 多选启动”。Full 版可在“设置中心 → 自动化”选择已初始化账号并开启 OCR。
 
-D2RHub 是非官方第三方工具，与 Blizzard Entertainment 不存在隶属、授权、赞助或背书关系。Diablo、Diablo II: Resurrected、Battle.net 及相关名称是 Blizzard Entertainment 的商标或注册商标。
+完整操作、统计口径、数据位置和排障方法见 [D2RHub v0.8 使用手册](docs/user-guide.html)。
 
-### 💬 反馈与交流
-如果您在使用中遇到任何问题，欢迎提出：
-*   [提交 Bug 或建议 (Issues)](https://github.com/gjy991229/D2RHub/issues)
-*   开发者 QQ：`980102315`
+### 数据与安全边界
 
-请勿在公开 Issue 中提交账号 Token、含个人路径的日志或其他敏感数据。安全问题请按 [安全政策](SECURITY.md) 私下报告。
+D2RHub 通过 Windows 进程、句柄、注册表、文件和窗口 API 管理本机环境，**不修改游戏文件、不写入游戏内存、不注入 DLL**。任何第三方工具仍可能受到游戏服务条款、反作弊策略、安全软件、系统权限和账号风控影响，请自行评估风险。
+
+运行数据保存在程序同级目录：
+
+- `config/global_config.json`：全局配置；
+- `config/accounts/`：账号元数据、DPAPI 加密 Token、Battle.net / UnifiedAuth 快照与账号设置；
+- `config/stateData/data.db`：OCR 场景和掉落数据库；
+- `config/stateData/img/`：高级符文截图；
+- `config/test/`：启用 OCR 调试后产生的图片和识别日志；
+- `logs/`：运行日志，最多自动保留 16 个。
+
+程序不会主动上传账号配置或 Token。联网范围包括 Battle.net Token 登录页面、GitHub Releases 更新接口和邪恶区域信息接口。请勿在公开 Issue 中提交 Token、账号目录、个人路径、包含隐私的日志或截图；安全问题请按 [安全政策](SECURITY.md) 私下报告。
+
+### 从源码开发
+
+```powershell
+npm install
+npm run dev
+npm test
+npm run build
+npm run build:full
+npm run build:lite
+```
+
+环境要求、项目结构和 Windows 构建细节见 [开发指南](docs/DEVELOPMENT.md)。提交修改前请阅读 [贡献指南](CONTRIBUTING.md)。
 
 ---
 
-## 🇺🇸 English Description
+## English
 
-D2RHub is a lightweight, player-friendly Windows utility designed for managing multiple accounts, enabling multi-boxing (multi-clienting), and OCR-based run tracking in **Diablo II: Resurrected (D2R)**.
+D2RHub is a local Windows utility for managing multiple Diablo II: Resurrected accounts, separate CN/Global client profiles, and multi-client launch workflows. The Full edition also includes screen OCR, run timing, rune-drop logging, and local analytics.
 
-### ✨ Features
-*   **🎮 Local Multi-Instance Management**: Bypass the D2R single-instance restriction automatically. D2RHub uses native Windows handle closing APIs, with no memory injection, DLL injection, or game-file modification.
-*   **🚀 Configuration Isolation**: Bind different Battle.net accounts, custom launch arguments (Mod support), and **independent save directories** for each profile.
-*   **⚙️ Graphical Settings Editor**: Tweak D2R's `Settings.json` with a full GUI. Apply graphics presets instantly (e.g., Ultra settings for your main character, Minimum settings for alt accounts to save GPU/CPU resources). If the save directory does not contain `Settings.json`, profile creation, login, and multiboxing remain available; only graphics configuration features are unavailable until the path or file is fixed.
-*   **📊 Hardware Load Monitor**: Real-time tracking of CPU, RAM, GPU, and Video Memory (VRAM) so you can monitor your computer's health while multi-boxing.
-*   **🪟 Desktop Overlay**: A semi-transparent always-on-top overlay supports expanded and mini layouts. Double-click the expanded background, double-click anywhere in mini mode, or focus the overlay and press Enter/Space to switch modes. Each mode remembers its own size. The mini layout reflows to one row at 36px high, can shrink to 18px, and returns to two rows when raised back to 36px. Double-clicking a profile in expanded mode focuses its game window.
-*   **⏱️ OCR Run Tracker**: Real-time OCR-based game screen analysis. Automatically records run timers, average times, and session run counts.
-*   **💎 Rune Drop Logging**: Automatically recognizes and logs high-value rune drops with visual stats.
-*   **🐱 Interactive Bongo Cat**: A cute animated desktop pet that mimics your keyboard strokes! It triggers unique visual animations when high-value loot (Uniques/Runes) drops in the game.
+### Current features
 
-### 🛠️ Quick Start
-1.  **Download**: Get the latest MSI or NSIS installer from the [Releases](https://github.com/gjy991229/D2RHub/releases) page.
-2.  **First Run**: The wizard will auto-detect your Battle.net, D2R game path, and save folders. Click **Save & Continue**.
-3.  **Manage Profiles**: Click **Add Account**, name it, click **Initialize**, select the accounts you wish to launch, and click **Launch**. D2RHub handles the login queue and clears the mutexes automatically.
+- **CN / Global profile isolation** with separate game, save, and Battle.net paths; KR, NA, and EU accounts share the Global installation profile.
+- **Two authentication modes**: direct Web Token launch, or Battle.net client authentication with a local runtime snapshot. Tokens are encrypted with Windows DPAPI.
+- **Multi-account launch controls**: launch one, launch all, multi-select, cancel a queue, inspect progress, reorder profiles, configure mod arguments, and assign window positions.
+- **Per-account game settings** for display, graphics, audio, gameplay, and automap, with system-settings and account-snapshot modes.
+- **Always-on-top performance overlay** with expanded and mini layouts, account/OCR/Terror Zone status, independent size persistence, and four-edge auto-hide docking. Hover to reveal it smoothly and move away to hide it again.
+- **High-DPI mini layout**: the stacked layout bottoms out at 36 logical pixels, then switches to a single row that can shrink to 18 pixels.
+- **OCR and local analytics (Full)**: scene and rune recognition, screenshots for runes #24+, global filters, timing percentiles, trends, scene/character comparisons, weekday-hour heatmaps, a 33-rune matrix, high-rune hit rate and intervals, screenshot gallery, record management, and filtered CSV/JSON export.
+- **Focus shortcuts and Bongo Cat**, including input reactions, scaling, chatter, and unlockable skins.
 
-### Security and Data
-D2RHub stores configuration, encrypted token data, registry snapshots, logs, OCR debug images, and local stats databases on your own machine. It does not intentionally upload account configuration or tokens. The app connects to Battle.net login pages, the GitHub Releases API, and a Terror Zone information API. Use of any third-party utility can still be affected by game terms, antivirus false positives, system permissions, and account risk controls.
+### Full vs. Lite
 
-Do not post account tokens, personal filesystem paths, or other sensitive data in public Issues. Report vulnerabilities privately according to the [Security Policy](SECURITY.md).
+| Capability | Full | Lite |
+| --- | :---: | :---: |
+| Account management, dual client profiles, multi-client launch | ✓ | ✓ |
+| Web Token and Battle.net authentication | ✓ | ✓ |
+| Game settings, overlay, shortcuts, desktop pet | ✓ | ✓ |
+| Scene/rune OCR, screenshots, and analytics | ✓ | — |
 
-### Development and Contributions
-See the [Development Guide](docs/DEVELOPMENT.md) for prerequisites, commands, and project structure. Contributions are welcome; please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+### Quick start
 
-### License and Trademarks
-Source code and original assets that D2RHub has the right to license are available under the [MIT License](LICENSE). OCR models, third-party dependencies, and trademarks remain subject to their own terms; see [Third-Party Notices](THIRD_PARTY_NOTICES.md).
+1. Download a Full or Lite MSI / NSIS installer from [Releases](https://github.com/gjy991229/D2RHub/releases).
+2. On first run, configure at least one complete **game directory + save directory** pair. Battle.net.exe is only required for Battle.net authentication. Game and Battle.net paths must be confirmed manually; save, Agent, Roaming, and Edge/Chrome paths can be detected.
+3. Click **Add Account** and follow the nickname, region, UI/voice language, and authentication steps. Acquire and paste a Web Token, or complete Battle.net login and initialization.
+4. Launch a profile from its card, or use **Launch All / Multi-select**. In the Full edition, select an initialized OCR target under **Settings → Automation**.
+
+See the [v0.8 User Manual](docs/user-guide.html) for complete workflows, metric definitions, local data paths, and troubleshooting.
+
+### Security and local data
+
+D2RHub uses Windows process, handle, registry, filesystem, and window APIs. It does **not** modify game files, write to game memory, or inject DLLs. Any third-party utility may still be affected by game terms, anti-cheat policy, antivirus software, system permissions, and account risk controls; evaluate those risks yourself.
+
+Runtime data is stored beside the executable in `config/` and `logs/`. This includes global settings, DPAPI-encrypted tokens, local Battle.net/UnifiedAuth snapshots, per-account game settings, OCR debug images, high-rune screenshots, and the SQLite stats database. D2RHub does not intentionally upload account configuration or tokens. Network access is used for Battle.net Token login, GitHub Releases update checks, and Terror Zone information.
+
+Never post tokens, account directories, personal paths, or sensitive logs/screenshots in a public Issue. Report vulnerabilities privately through the [Security Policy](SECURITY.md).
+
+### Development
+
+```powershell
+npm install
+npm run dev
+npm test
+npm run build
+npm run build:full
+npm run build:lite
+```
+
+See the [Development Guide](docs/DEVELOPMENT.md) for prerequisites, project structure, and Windows build details. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a change.
+
+### License and trademarks
+
+Source code and original assets that D2RHub has the right to license are available under the [MIT License](LICENSE). OCR models, dependencies, and third-party marks remain under their own terms; see [Third-Party Notices](THIRD_PARTY_NOTICES.md).
 
 D2RHub is an unofficial third-party project and is not affiliated with, authorized, sponsored, or endorsed by Blizzard Entertainment. Diablo, Diablo II: Resurrected, Battle.net, and related names are trademarks or registered trademarks of Blizzard Entertainment.
 
 ---
 
 <div align="center">
-  <p>
-    <a href="https://github.com/gjy991229/D2RHub/issues">Report Bug</a> ·
-    <a href="https://github.com/gjy991229/D2RHub/discussions">Discussions</a>
-  </p>
+  <a href="https://github.com/gjy991229/D2RHub/issues">Report a bug</a> ·
+  <a href="https://github.com/gjy991229/D2RHub/discussions">Discussions</a>
 </div>

--- a/docs/stats.html
+++ b/docs/stats.html
@@ -1,608 +1,102 @@
-<!DOCTYPE html>
-<html lang="zh-CN" data-theme="dark">
+<!doctype html>
+<html lang="zh-CN" data-theme="{{STATS_THEME}}">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>运行统计 - D2RHub</title>
-<style>
-  :root {
-    --bg-main: #09090b;
-    --bg-surface: #18181b;
-    --bg-panel: #27272a;
-    --border: #3f3f46;
-    --border-hover: #52525b;
-    --text-primary: #f4f4f5;
-    --text-secondary: #a1a1aa;
-    --accent: #3b82f6;
-    --accent-hover: #60a5fa;
-    --danger: #ef4444;
-    --danger-hover: #f87171;
-    --success: #10b981;
-    --radius: 8px;
-  }
-  [data-theme="light"] {
-    --bg-main: #f4f4f5;
-    --bg-surface: #ffffff;
-    --bg-panel: #f4f4f5;
-    --border: #e4e4e7;
-    --border-hover: #d4d4d8;
-    --text-primary: #18181b;
-    --text-secondary: #52525b;
-    --accent: #2563eb;
-    --accent-hover: #3b82f6;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    background: var(--bg-main);
-    color: var(--text-primary);
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
-  }
-  header {
-    background: var(--bg-surface);
-    border-bottom: 1px solid var(--border);
-    padding: 1rem 2rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  .tabs { display: flex; gap: 1rem; }
-  .tab-btn {
-    background: none; border: none; color: var(--text-secondary);
-    padding: 0.5rem 1rem; border-radius: var(--radius); cursor: pointer;
-    font-size: 1rem; transition: all 0.2s;
-  }
-  .tab-btn:hover { background: var(--bg-panel); color: var(--text-primary); }
-  .tab-btn.active { background: var(--bg-panel); color: var(--accent); font-weight: bold; }
-  .theme-toggle {
-    background: transparent; border: 1px solid var(--border); color: var(--text-primary);
-    padding: 0.25rem 0.5rem; border-radius: var(--radius); cursor: pointer;
-  }
-  main { flex: 1; overflow-y: auto; padding: 2rem; }
-  .view { display: none; }
-  .view.active { display: block; }
-  .card {
-    background: var(--bg-surface); border: 1px solid var(--border);
-    border-radius: var(--radius); padding: 1.5rem; margin-bottom: 1.5rem;
-  }
-  .grid-cards {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem;
-  }
-  .card-title { font-size: 0.9rem; color: var(--text-secondary); margin-bottom: 0.5rem; }
-  .card-value { font-size: 1.8rem; font-weight: 600; color: var(--text-primary); }
-  .toolbar {
-    display: flex; gap: 1rem; flex-wrap: wrap; align-items: center;
-    background: var(--bg-surface); padding: 1rem; border-radius: var(--radius);
-    border: 1px solid var(--border); margin-bottom: 1rem;
-  }
-  .form-group { display: flex; flex-direction: column; gap: 0.25rem; }
-  .form-group label { font-size: 0.8rem; color: var(--text-secondary); }
-  .input, .select {
-    background: var(--bg-main); border: 1px solid var(--border);
-    color: var(--text-primary); padding: 0.4rem 0.8rem; border-radius: var(--radius);
-  }
-  .btn {
-    background: var(--bg-panel); border: 1px solid var(--border);
-    color: var(--text-primary); padding: 0.4rem 0.8rem; border-radius: var(--radius);
-    cursor: pointer; transition: all 0.2s;
-  }
-  .btn:hover { background: var(--border); }
-  .btn-danger { color: var(--danger); }
-  .btn-danger:hover { background: var(--danger); color: #fff; border-color: var(--danger); }
-  .chart-container { position: relative; height: 350px; width: 100%; margin-top: 1rem; }
-  table { width: 100%; border-collapse: collapse; text-align: left; }
-  .table-scroll { width: 100%; overflow-x: auto; }
-  th, td { padding: 0.75rem 1rem; border-bottom: 1px solid var(--border); }
-  th { background: var(--bg-panel); color: var(--text-secondary); font-size: 0.9rem; }
-  tr:hover td { background: var(--bg-panel); }
-  .tag {
-    background: var(--bg-panel); border: 1px solid var(--border); padding: 0.1rem 0.5rem;
-    border-radius: 999px; font-size: 0.8rem; margin-right: 0.25rem; display: inline-block;
-  }
-  .tag-rune { background: rgba(59, 130, 246, 0.1); color: var(--accent); border-color: rgba(59, 130, 246, 0.2); }
-  .tag-rune-del { cursor: pointer; color: var(--danger); margin-left: 0.25rem; font-weight: bold; }
-
-  .css-chart { display: flex; align-items: flex-end; justify-content: space-around; height: 100%; padding-top: 20px; gap: 4px; }
-  .css-bar-container { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: flex-end; height: 100%; min-width: 0; }
-  .css-bar-group { display: flex; align-items: flex-end; justify-content: center; width: 100%; height: 100%; gap: 2px; }
-  .css-bar { width: 100%; transform-origin: bottom; animation: grow-y 0.5s ease-out both; }
-  .css-label { font-size: 10px; margin-top: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; width: 100%; text-align: center; color: var(--text-secondary); }
-  .css-chart-horiz { display: flex; flex-direction: column; gap: 8px; height: 100%; overflow-y: auto; padding-right: 8px; }
-  .css-bar-row { display: flex; align-items: center; gap: 8px; }
-  .css-row-label { width: 100px; text-align: right; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--text-secondary); }
-  .css-row-bar-bg { flex: 1; background: var(--bg-panel); height: 16px; border-radius: 4px; overflow: hidden; }
-  .css-row-bar { height: 100%; transform-origin: left; animation: grow-x 0.5s ease-out both; }
-  .css-row-val { width: 30px; font-size: 11px; color: var(--text-primary); text-align: left; }
-  .empty-state { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--text-secondary); font-size: 0.9rem; }
-  .tag-rune-del { cursor: pointer; color: var(--danger); margin-left: 0.25rem; font-weight: bold; }
-  .scene-rename { cursor: pointer; border-bottom: 1px dashed var(--border); }
-  @keyframes grow-y { from { transform: scaleY(0); opacity: 0.35; } to { transform: scaleY(1); opacity: 1; } }
-  @keyframes grow-x { from { transform: scaleX(0); opacity: 0.35; } to { transform: scaleX(1); opacity: 1; } }
-  @media (max-width: 720px) {
-    header { padding: 0.9rem 1rem; gap: 0.75rem; }
-    .tabs { gap: 0.4rem; }
-    .tab-btn { padding: 0.45rem 0.65rem; font-size: 0.9rem; white-space: nowrap; }
-    .theme-toggle { padding: 0.35rem 0.55rem; }
-    main { padding: 1rem; }
-    .toolbar { gap: 0.75rem; }
-    .form-group { min-width: min(145px, 100%); }
-    .chart-container { height: 260px; }
-    th, td { padding: 0.65rem 0.75rem; }
-  }
-</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>D2RHub OCR 数据中心</title>
+  <style>
+    :root{color-scheme:dark;--surface-base:#000;--surface-glass:#080808;--surface-card:#0d0d0d;--surface-tile:#121212;--surface-tile-soft:#0d0d0d;--surface-control:#121212;--surface-hover:#171717;--surface-active:#1f1f1f;--border-default:#2e2e2e;--border-strong:#505050;--border-focus:#b8b8b8;--text-primary:#f5f5f5;--text-secondary:#d0d0d0;--text-muted:#a3a3a3;--accent:#f5f5f5;--accent-rgb:245 245 245;--cta-text:#080808;--success:#4ade80;--warning:#facc15;--danger:#fb7185;--info:#60a5fa;--violet:#c084fc;--radius-xs:8px;--radius-sm:10px;--radius-md:12px;--radius-card:16px;--radius-full:9999px;--header:44px;--ease-out-expo:cubic-bezier(.16,1,.3,1);--duration-fast:180ms;--duration-normal:260ms;--shadow-card:0 2px 8px rgba(0,0,0,.72)}
+    [data-theme="light"]{color-scheme:light;--surface-base:#f3f5f8;--surface-glass:rgba(249,250,252,.9);--surface-card:rgba(255,255,255,.86);--surface-tile:rgba(255,255,255,.92);--surface-tile-soft:rgba(255,255,255,.78);--surface-control:rgba(255,255,255,.82);--surface-hover:rgba(0,0,0,.035);--surface-active:rgba(0,0,0,.065);--border-default:rgba(24,30,42,.07);--border-strong:rgba(24,30,42,.14);--border-focus:#1a1a1c;--text-primary:#1a1a1c;--text-secondary:rgba(26,26,28,.62);--text-muted:rgba(26,26,28,.48);--accent:#1a1a1c;--accent-rgb:26 26 28;--cta-text:#fff;--success:#34c759;--warning:#c87800;--danger:#ff3b30;--info:#1684b8;--violet:#7e22ce;--shadow-card:0 1px 1px rgba(12,18,28,.035),0 6px 8px rgba(12,18,28,.035)}
+    *{box-sizing:border-box}html{background:var(--surface-base);scroll-behavior:smooth}body{margin:0;min-width:320px;background:var(--surface-base);color:var(--text-primary);font:13px/1.45 Inter,-apple-system,BlinkMacSystemFont,"Segoe UI","Microsoft YaHei","PingFang SC",sans-serif;-webkit-font-smoothing:antialiased}button,input,select{font:inherit}button,select{cursor:pointer}button:focus-visible,input:focus-visible,select:focus-visible,summary:focus-visible{outline:2px solid var(--border-focus);outline-offset:2px}::selection{background:rgb(var(--accent-rgb)/.16);color:var(--text-primary)}
+    .app-header{position:sticky;top:0;z-index:20;height:var(--header);display:flex;align-items:center;justify-content:space-between;gap:14px;padding:0 max(18px,calc((100vw - 1320px)/2));background:var(--surface-glass);border-bottom:1px solid var(--border-default)}.brand{display:flex;align-items:center;gap:9px;min-width:0}.swiss-mark{width:28px;height:28px;display:grid;place-items:center;border:1px solid var(--border-default);border-radius:var(--radius-sm);background:rgb(var(--accent-rgb)/.06);color:var(--text-secondary)}.swiss-mark svg{width:15px;height:15px}.brand-name{font-size:11px;font-weight:680;color:var(--text-secondary)}.brand-divider{width:1px;height:14px;background:var(--border-default)}.product-area,.sync-state{color:var(--text-muted);font-size:10px;font-weight:660;white-space:nowrap}.header-actions{display:flex;align-items:center;gap:7px}
+    .button{height:30px;padding:0 12px;border:1px solid var(--border-default);border-radius:var(--radius-md);background:var(--surface-control);color:var(--text-secondary);font-size:11px;font-weight:760;white-space:nowrap;transition:transform var(--duration-fast) var(--ease-out-expo),background var(--duration-normal) var(--ease-out-expo),border-color var(--duration-normal) var(--ease-out-expo),color var(--duration-normal) var(--ease-out-expo)}.button:hover{background:var(--surface-hover);border-color:var(--border-strong);color:var(--text-primary)}.button:active{transform:scale(.97)}.button:disabled{opacity:.34;cursor:not-allowed;transform:none}.button-primary{background:rgb(var(--accent-rgb)/.08);border-color:rgb(var(--accent-rgb)/.14);color:var(--text-primary)}.button-danger{color:var(--danger);border-color:color-mix(in srgb,var(--danger) 20%,var(--border-default));background:color-mix(in srgb,var(--danger) 5%,var(--surface-control))}.button-small{height:26px;padding:0 8px;border-radius:9px;font-size:10px}.layout{width:min(1320px,100%);margin:auto;padding:16px 18px 28px}
+    .intro{display:flex;align-items:center;justify-content:space-between;gap:24px;margin:2px 0 12px;padding:4px 2px}.intro h1{margin:0;font-size:17px;line-height:1.15;font-weight:780;letter-spacing:-.015em;text-wrap:balance}.intro p{margin:4px 0 0;max-width:72ch;color:var(--text-muted);font-size:10px;font-weight:620}.tabs{display:flex;gap:5px}.tab{height:30px;padding:0 13px;border:1px solid var(--border-default);border-radius:var(--radius-md);background:var(--surface-control);color:var(--text-secondary);font-size:11px;font-weight:760;transition:transform var(--duration-fast) var(--ease-out-expo),background var(--duration-normal) var(--ease-out-expo),border-color var(--duration-normal) var(--ease-out-expo),color var(--duration-normal) var(--ease-out-expo)}.tab:hover{color:var(--text-primary);background:var(--surface-hover);border-color:var(--border-strong)}.tab:active{transform:scale(.97)}.tab[aria-selected="true"]{color:var(--text-primary);background:rgb(var(--accent-rgb)/.08);border-color:rgb(var(--accent-rgb)/.2)}
+    .filters{position:sticky;top:calc(var(--header) + 8px);z-index:15;display:flex;align-items:end;gap:9px;padding:11px;margin-bottom:12px;border:1px solid var(--border-default);border-radius:var(--radius-card);background:linear-gradient(180deg,var(--surface-tile),var(--surface-tile-soft));box-shadow:inset 0 1px 0 rgba(255,255,255,.04),var(--shadow-card)}.filter-field{min-width:122px;flex:1 1 145px}.filter-field label{display:block;margin:0 0 4px;color:var(--text-muted);font-size:9px;font-weight:760}.control{width:100%;height:30px;padding:0 9px;border:1px solid var(--border-default);border-radius:var(--radius-md);background:var(--surface-control);color:var(--text-primary);font-size:10px;font-weight:650;outline:none;transition:border-color var(--duration-normal) var(--ease-out-expo),background var(--duration-normal) var(--ease-out-expo),box-shadow var(--duration-normal) var(--ease-out-expo)}.control:hover{border-color:var(--border-strong)}.control:focus{border-color:rgb(var(--accent-rgb)/.32);box-shadow:0 0 0 3px rgb(var(--accent-rgb)/.08)}.filter-summary{flex:1.7 1 230px;align-self:center;color:var(--text-muted);font-size:10px;font-weight:650}.view[hidden]{display:none}
+    .kpi-strip{display:grid;grid-template-columns:repeat(6,minmax(118px,1fr));gap:10px}.kpi{min-width:0;padding:12px 13px;border:1px solid var(--border-default);border-radius:var(--radius-card);background:linear-gradient(180deg,var(--surface-tile),var(--surface-tile-soft));box-shadow:inset 0 1px 0 rgba(255,255,255,.04)}.kpi-label{color:var(--text-muted);font-size:9px;font-weight:760}.kpi-value{margin-top:5px;font-size:18px;line-height:1;font-weight:780;letter-spacing:-.015em;font-variant-numeric:tabular-nums}.kpi-note{margin-top:5px;color:var(--text-muted);font-size:9px;font-weight:620;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .dashboard-grid{display:grid;grid-template-columns:minmax(0,1.65fr) minmax(300px,1fr);gap:12px;margin-top:12px}.panel{min-width:0;border:1px solid var(--border-default);border-radius:var(--radius-card);background:linear-gradient(180deg,var(--surface-tile),var(--surface-tile-soft));box-shadow:inset 0 1px 0 rgba(255,255,255,.04);overflow:hidden}.panel-wide{grid-column:1/-1}.panel-header{min-height:48px;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-bottom:1px solid var(--border-default)}.panel-title{margin:0;font-size:12px;line-height:1.1;font-weight:780}.panel-description{margin-top:4px;color:var(--text-muted);font-size:9px;font-weight:620}.panel-body{padding:12px}.panel-body-flush{padding:0}.metric-select{width:auto;min-width:126px}.empty{display:grid;place-items:center;min-height:140px;padding:22px;color:var(--text-muted);font-size:10px;text-align:center}
+    .chart-frame{min-height:258px;overflow-x:auto}.chart-frame svg{display:block;width:100%;min-width:620px;height:258px}.chart-grid-line{stroke:var(--border-default);stroke-width:1}.chart-label{fill:var(--text-muted);font-size:9px}.chart-bar{fill:var(--info);opacity:.72}.chart-area{fill:color-mix(in srgb,var(--info) 12%,transparent)}.chart-line{fill:none;stroke:var(--info);stroke-width:2;vector-effect:non-scaling-stroke}.chart-point{fill:var(--surface-tile-soft);stroke:var(--info);stroke-width:2;vector-effect:non-scaling-stroke}
+    .data-table-wrap{overflow:auto}table{width:100%;border-collapse:collapse;font-size:10px}th{position:sticky;top:0;z-index:2;padding:8px 9px;background:var(--surface-control);color:var(--text-muted);text-align:left;font-size:9px;font-weight:780;white-space:nowrap}td{padding:8px 9px;border-top:1px solid var(--border-default);color:var(--text-secondary);vertical-align:middle}tbody tr{transition:background var(--duration-fast) var(--ease-out-expo)}tbody tr:hover{background:var(--surface-hover)}.number{text-align:right;font-variant-numeric:tabular-nums}.scene-name{max-width:220px;color:var(--text-primary);font-weight:720}.subtle{color:var(--text-muted)}.inline-meter{display:inline-flex;align-items:center;gap:7px;min-width:92px}.inline-meter-track{width:50px;height:4px;overflow:hidden;border-radius:var(--radius-full);background:var(--surface-active)}.inline-meter-fill{height:100%;border-radius:inherit;background:var(--info)}
+    .comparison-list{display:flex;flex-direction:column;gap:10px}.comparison-row{display:grid;grid-template-columns:minmax(80px,1fr) 2.2fr auto;align-items:center;gap:10px}.comparison-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-secondary);font-size:10px;font-weight:720}.comparison-track{height:6px;overflow:hidden;border-radius:var(--radius-full);background:var(--surface-active)}.comparison-fill{height:100%;border-radius:inherit;background:var(--success)}.comparison-value{color:var(--text-muted);font-size:10px;font-weight:650;font-variant-numeric:tabular-nums}
+    .heatmap-wrap{overflow-x:auto}.heatmap{display:grid;grid-template-columns:32px repeat(24,minmax(18px,1fr));gap:3px;min-width:720px;align-items:center}.heatmap-label{color:var(--text-muted);font-size:9px;text-align:right;padding-right:4px}.heatmap-hour{color:var(--text-muted);font-size:8px;text-align:center}.heatmap-cell{aspect-ratio:1;min-height:14px;border:1px solid rgb(var(--accent-rgb)/.025);border-radius:4px;background:var(--surface-active)}
+    .rune-summary{display:grid;grid-template-columns:repeat(4,1fr);border-bottom:1px solid var(--border-default)}.rune-tier{padding:11px 12px;border-right:1px solid var(--border-default)}.rune-tier:last-child{border-right:0}.rune-tier strong{display:block;margin-top:4px;font-size:16px;font-weight:780;font-variant-numeric:tabular-nums}.rune-tier span{color:var(--text-muted);font-size:9px;font-weight:680}.rune-matrix{display:grid;grid-template-columns:repeat(11,minmax(58px,1fr));gap:7px}.rune-cell{min-width:0;padding:8px;border:1px solid var(--border-default);border-radius:11px;background:var(--surface-control);color:var(--text-primary);text-align:left;transition:transform var(--duration-fast) var(--ease-out-expo),background var(--duration-normal) var(--ease-out-expo),border-color var(--duration-normal) var(--ease-out-expo)}.rune-cell:hover{transform:translateY(-1px);background:var(--surface-hover);border-color:var(--border-strong)}.rune-cell[data-active="true"]{border-color:rgb(var(--accent-rgb)/.3);background:rgb(var(--accent-rgb)/.08)}.rune-number{color:var(--text-muted);font-size:8px;font-weight:760}.rune-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:10px;font-weight:760}.rune-count{margin-top:5px;color:var(--text-muted);font-size:9px;font-variant-numeric:tabular-nums}.rune-cell[data-tier="high"] .rune-name{color:var(--warning)}.rune-cell[data-tier="elite"] .rune-name{color:var(--violet)}
+    .gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(190px,1fr));gap:10px}.gallery-item{overflow:hidden;border:1px solid var(--border-default);border-radius:var(--radius-card);background:var(--surface-control);color:inherit;text-decoration:none;transition:transform var(--duration-normal) var(--ease-out-expo),border-color var(--duration-normal) var(--ease-out-expo)}.gallery-item:hover{transform:translateY(-1px);border-color:var(--border-strong)}.gallery-item img{display:block;width:100%;aspect-ratio:16/9;object-fit:cover;background:var(--surface-base)}.gallery-caption{padding:9px 10px}.gallery-caption strong{display:block;color:var(--warning);font-size:10px}.gallery-caption span{display:block;margin-top:3px;color:var(--text-muted);font-size:9px}
+    .records-toolbar{display:flex;flex-wrap:wrap;gap:7px;padding:10px 11px;border-bottom:1px solid var(--border-default)}.records-search{flex:1 1 280px}.record-drops{display:flex;flex-wrap:wrap;gap:4px;min-width:160px}.drop-chip{height:18px;display:inline-flex;align-items:center;gap:4px;padding:0 6px;border:1px solid var(--border-default);border-radius:5px;background:rgb(var(--accent-rgb)/.055);color:var(--text-secondary);font-size:9px;font-weight:720;white-space:nowrap}.drop-chip.high{border-color:color-mix(in srgb,var(--warning) 34%,var(--border-default));background:color-mix(in srgb,var(--warning) 8%,var(--surface-control));color:var(--warning)}.drop-delete{padding:0;border:0;background:none;color:var(--text-muted);line-height:1}.drop-delete:hover{color:var(--danger)}.pagination{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:9px 11px;border-top:1px solid var(--border-default)}.pagination-state{color:var(--text-muted);font-size:10px}
+    .methodology{margin-top:12px;border:1px solid var(--border-default);border-radius:var(--radius-card);background:linear-gradient(180deg,var(--surface-tile),var(--surface-tile-soft));box-shadow:inset 0 1px 0 rgba(255,255,255,.04)}.methodology summary{padding:10px 12px;cursor:pointer;color:var(--text-secondary);font-size:10px;font-weight:760}.methodology-content{padding:0 12px 12px;color:var(--text-muted);font-size:10px}.methodology-content ul{margin:6px 0 0;padding-left:18px}.methodology-content li+li{margin-top:5px}.toast{position:fixed;right:16px;bottom:16px;z-index:50;max-width:min(420px,calc(100vw - 32px));padding:9px 11px;border:1px solid var(--border-default);border-radius:var(--radius-md);background:var(--surface-card);color:var(--text-primary);box-shadow:var(--shadow-card);font-size:10px;font-weight:720;opacity:0;transform:translateY(8px);pointer-events:none;transition:opacity var(--duration-fast) var(--ease-out-expo),transform var(--duration-normal) var(--ease-out-expo)}.toast.show{opacity:1;transform:none}
+    @media(max-width:1080px){.kpi-strip{grid-template-columns:repeat(3,1fr)}.dashboard-grid{grid-template-columns:1fr}.panel-wide{grid-column:auto}.rune-matrix{grid-template-columns:repeat(7,minmax(58px,1fr))}}
+    @media(max-width:760px){:root{--header:44px}.app-header{padding:0 12px}.product-area,.brand-divider,.sync-state{display:none}.layout{padding:12px}.intro{align-items:flex-start;flex-direction:column;gap:10px}.tabs{width:100%}.tab{flex:1;padding-inline:6px}.filters{top:calc(var(--header) + 6px);overflow-x:auto;border-radius:var(--radius-md)}.filter-field{min-width:132px}.filter-summary{display:none}.kpi-strip{grid-template-columns:repeat(2,1fr);gap:8px}.kpi{border-radius:var(--radius-md)}.rune-summary{grid-template-columns:repeat(2,1fr)}.rune-tier:nth-child(2){border-right:0}.rune-tier:nth-child(-n+2){border-bottom:1px solid var(--border-default)}.rune-matrix{grid-template-columns:repeat(4,minmax(58px,1fr))}}
+    @media(prefers-reduced-motion:reduce){*,*::before,*::after{scroll-behavior:auto!important;transition-duration:.01ms!important}}
+  </style>
 </head>
 <body>
-<header>
-  <div class="tabs">
-    <button class="tab-btn active" data-target="view-dashboard">高级仪表盘</button>
-    <button class="tab-btn" data-target="view-records">原始记录管理</button>
-  </div>
-  <div><button class="theme-toggle" id="themeToggle">切换主题</button></div>
-</header>
-
-<main>
-  <div id="view-dashboard" class="view active">
-    <!-- Controls -->
-    <div class="toolbar">
-      <div class="form-group">
-        <label>日期范围 - 起</label>
-        <input type="date" class="input" id="filter-date-start">
+  <header class="app-header"><div class="brand"><span class="swiss-mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m7 16 4-5 4 3 5-7"/></svg></span><span class="brand-name">D2RHub</span><span class="brand-divider" aria-hidden="true"></span><span class="product-area">OCR 数据中心</span></div><div class="header-actions"><span class="sync-state" id="sync-state">本地数据</span><button class="button button-small" id="theme-toggle" type="button">浅色</button><button class="button button-small" id="refresh-data" type="button">刷新</button></div></header>
+  <main class="layout">
+    <div class="intro"><div><h1>刷图与符文统计</h1><p>所有结果均由本机 OCR 场景记录计算。先选择范围，再查看效率、掉落分布与原始记录。</p></div><nav class="tabs" role="tablist" aria-label="统计视图"><button class="tab" role="tab" aria-selected="true" data-view="overview">总览</button><button class="tab" role="tab" aria-selected="false" data-view="runes">符文</button><button class="tab" role="tab" aria-selected="false" data-view="records">记录</button></nav></div>
+    <section class="filters" aria-label="统计筛选">
+      <div class="filter-field"><label for="filter-period">时间范围</label><select class="control" id="filter-period"><option value="all">全部时间</option><option value="today">今天</option><option value="7">最近 7 天</option><option value="30">最近 30 天</option><option value="90">最近 90 天</option></select></div>
+      <div class="filter-field"><label for="filter-character">角色</label><select class="control" id="filter-character"><option value="">全部角色</option></select></div>
+      <div class="filter-field"><label for="filter-scene">场景</label><select class="control" id="filter-scene"><option value="">全部场景</option></select></div>
+      <div class="filter-field"><label for="filter-drop">掉落条件</label><select class="control" id="filter-drop"><option value="all">不限掉落</option><option value="any">有符文</option><option value="none">无符文</option><option value="high">高级符文 #24+</option><option value="screenshot">有留存截图</option></select></div>
+      <div class="filter-field"><label for="filter-rune">指定符文</label><select class="control" id="filter-rune"><option value="">全部符文</option></select></div>
+      <div class="filter-summary" id="filter-summary">正在读取记录…</div><button class="button" type="button" id="reset-filters">重置</button>
+    </section>
+    <section class="view" id="view-overview" role="tabpanel">
+      <div class="kpi-strip" id="kpi-strip"></div>
+      <div class="dashboard-grid">
+        <section class="panel panel-wide"><div class="panel-header"><div><h2 class="panel-title">趋势</h2><div class="panel-description">按自然日聚合，随上方筛选同步</div></div><select class="control metric-select" id="trend-metric"><option value="runs">每日场次</option><option value="avg">平均耗时</option><option value="drops">符文掉落</option><option value="high">高级符文</option></select></div><div class="panel-body chart-frame" id="trend-chart"></div></section>
+        <section class="panel"><div class="panel-header"><div><h2 class="panel-title">场景效率</h2><div class="panel-description">平均、P90 与百场掉落</div></div></div><div class="panel-body panel-body-flush data-table-wrap" id="scene-table"></div></section>
+        <section class="panel"><div class="panel-header"><div><h2 class="panel-title">角色对比</h2><div class="panel-description">场次数量与平均耗时</div></div></div><div class="panel-body" id="character-comparison"></div></section>
+        <section class="panel panel-wide"><div class="panel-header"><div><h2 class="panel-title">活跃时段</h2><div class="panel-description">星期 × 小时；颜色越实，记录越集中</div></div></div><div class="panel-body heatmap-wrap" id="activity-heatmap"></div></section>
       </div>
-      <div class="form-group">
-        <label>日期范围 - 止</label>
-        <input type="date" class="input" id="filter-date-end">
+    </section>
+    <section class="view" id="view-runes" role="tabpanel" hidden>
+      <div class="dashboard-grid">
+        <section class="panel panel-wide"><div class="rune-summary" id="rune-summary"></div><div class="panel-header"><div><h2 class="panel-title">符文图谱</h2><div class="panel-description">点击任一符文可筛选包含该符文的场次</div></div></div><div class="panel-body rune-matrix" id="rune-matrix"></div></section>
+        <section class="panel"><div class="panel-header"><div><h2 class="panel-title">掉落排行</h2><div class="panel-description">按独立掉落实例计数</div></div></div><div class="panel-body" id="rune-ranking"></div></section>
+        <section class="panel"><div class="panel-header"><div><h2 class="panel-title">高级符文效率</h2><div class="panel-description">#24 以上掉落率及间隔</div></div></div><div class="panel-body" id="high-rune-insights"></div></section>
+        <section class="panel panel-wide"><div class="panel-header"><div><h2 class="panel-title">高级符文截图</h2><div class="panel-description">仅展示数据库中仍有截图路径的掉落</div></div></div><div class="panel-body gallery" id="screenshot-gallery"></div></section>
       </div>
-      <div class="form-group">
-        <label>角色</label>
-        <select class="select" id="filter-character">
-          <option value="">所有角色</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label>场景</label>
-        <select class="select" id="filter-scene">
-          <option value="">所有场景</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label>掉落过滤</label>
-        <select class="select" id="filter-drop">
-          <option value="">全部</option>
-          <option value="has_drop">有掉落</option>
-          <option value="high_rune">高阶符文 (>=#24)</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label>分组依据 (用于分组图表)</label>
-        <select class="select" id="group-by">
-          <option value="scene">场景</option>
-          <option value="character">角色</option>
-          <option value="date">日期 (YYYY-MM-DD)</option>
-          <option value="weekday">星期</option>
-          <option value="hour">小时 (0-23)</option>
-          <option value="rune">符文 (Rune)</option>
-        </select>
-      </div>
-      <div style="flex: 1;"></div>
-      <button class="btn" id="btn-apply-filters">应用分析</button>
-    </div>
-
-    <!-- KPIs -->
-    <div class="grid-cards">
-      <div class="card"><div class="card-title">过滤后运行次数</div><div class="card-value" id="kpi-runs">0</div></div>
-      <div class="card"><div class="card-title">过滤后总耗时</div><div class="card-value" id="kpi-time">0h 0m</div></div>
-      <div class="card"><div class="card-title">过滤后掉落数</div><div class="card-value" id="kpi-drops">0</div></div>
-      <div class="card"><div class="card-title">高阶符文 (>=24)</div><div class="card-value" id="kpi-high-runes">0</div></div>
-    </div>
-
-    <!-- Charts -->
-    <div class="card">
-      <h3 style="margin-bottom:1rem;">总览趋势 / 时间分布</h3>
-      <div class="chart-container" id="chart-trend"></div>
-    </div>
-    <div class="card">
-      <h3 style="margin-bottom:1rem;">分组排行统计</h3>
-      <div class="chart-container" id="chart-grouped"></div>
-    </div>
-    <div class="card">
-      <h3 style="margin-bottom:1rem;">符文/物品 掉落分布</h3>
-      <div class="chart-container" id="chart-runes"></div>
-    </div>
-  </div>
-
-  <div id="view-records" class="view">
-    <div class="toolbar">
-      <input type="text" class="input" id="records-search" placeholder="搜索角色/场景/物品..." style="flex:1;">
-      <button class="btn" id="btn-batch-rename-scene">批量重命名场景</button>
-      <button class="btn" id="btn-export-csv">导出 CSV</button>
-      <button class="btn" id="btn-refresh">刷新数据</button>
-    </div>
-    <div class="card" style="padding:0; overflow:hidden;">
-      <div class="table-scroll">
-        <table id="records-table">
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>时间</th>
-              <th>角色</th>
-              <th>场景</th>
-              <th>耗时 (s)</th>
-              <th>掉落</th>
-              <th>操作</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-</main>
-
-<script>
-
-  // Theme Toggle
-  const themeToggle = document.getElementById('themeToggle');
-  const htmlEl = document.documentElement;
-  const savedTheme = localStorage.getItem('d2rhub-theme') || 'dark';
-  htmlEl.setAttribute('data-theme', savedTheme);
-  themeToggle.addEventListener('click', () => {
-    const currentTheme = htmlEl.getAttribute('data-theme');
-    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    htmlEl.setAttribute('data-theme', newTheme);
-    localStorage.setItem('d2rhub-theme', newTheme);
-  });
-
-  // Tabs
-  document.querySelectorAll('.tab-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-      document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
-      btn.classList.add('active');
-      document.getElementById(btn.dataset.target).classList.add('active');
-    });
-  });
-
-  // State
-  let STATE = { records: [] };
-  const RAW_STATS_DATA = {{STATS_DATA}};
-  const STATS_API_PORT = {{STATS_API_PORT}};
-
-  function initData() {
-    STATE.records = RAW_STATS_DATA.records || [];
-    populateFilters();
-    analyzeData();
-    renderRecords();
-  }
-
-  function escapeHtml(v) { return String(v||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
-
-  function populateFilters() {
-    const chars = new Set();
-    const scenes = new Set();
-    STATE.records.forEach(r => {
-      if(r.character_name) chars.add(r.character_name);
-      if(r.scene_name) scenes.add(r.scene_name);
-    });
-
-    const charSelect = document.getElementById('filter-character');
-    charSelect.options.length = 1;
-    [...chars].sort().forEach(c => charSelect.add(new Option(c, c)));
-    const sceneSelect = document.getElementById('filter-scene');
-    sceneSelect.options.length = 1;
-    [...scenes].sort().forEach(s => sceneSelect.add(new Option(s, s)));
-  }
-
-  document.getElementById('btn-apply-filters').addEventListener('click', analyzeData);
-
-  function analyzeData() {
-    const ds = document.getElementById('filter-date-start').value;
-    const de = document.getElementById('filter-date-end').value;
-    const char = document.getElementById('filter-character').value;
-    const scene = document.getElementById('filter-scene').value;
-    const dropF = document.getElementById('filter-drop').value;
-    const groupBy = document.getElementById('group-by').value;
-
-    let filtered = STATE.records.filter(r => {
-      const dDate = (r.absolute_time || '').split(' ')[0];
-      if(ds && dDate < ds) return false;
-      if(de && dDate > de) return false;
-      if(char && r.character_name !== char) return false;
-      if(scene && r.scene_name !== scene) return false;
-
-      const drops = r.drops || [];
-      if(dropF === 'has_drop' && drops.length === 0) return false;
-      if(dropF === 'high_rune' && !drops.some(d => Number(d.rune_number) >= 24)) return false;
-      return true;
-    });
-
-    // KPI
-    let tTime = 0, tDrops = 0, tHigh = 0;
-    filtered.forEach(r => {
-      tTime += r.timer_seconds || 0;
-      tDrops += (r.drops || []).length;
-      tHigh += (r.drops || []).filter(d => Number(d.rune_number) >= 24).length;
-    });
-    document.getElementById('kpi-runs').textContent = filtered.length;
-    document.getElementById('kpi-time').textContent = Math.floor(tTime/3600) + 'h ' + Math.floor((tTime%3600)/60) + 'm';
-    document.getElementById('kpi-drops').textContent = tDrops;
-    document.getElementById('kpi-high-runes').textContent = tHigh;
-
-    renderTrendChart(filtered);
-    renderGroupedChart(filtered, groupBy);
-    renderRunesChart(filtered);
-  }
-
-  function getGroupKey(r, groupBy, drop) {
-    if(groupBy === 'rune') return drop ? (drop.rune_name || 'Unknown') : 'Unknown';
-    if(groupBy === 'scene') return r.scene_name || 'Unknown';
-    if(groupBy === 'character') return r.character_name || 'Unknown';
-    if(groupBy === 'date') return (r.absolute_time || '').split(' ')[0] || 'Unknown';
-    if(groupBy === 'hour') return (r.absolute_time || '').split(' ')[1]?.split(':')[0] || 'Unknown';
-    if(groupBy === 'weekday') {
-      const d = new Date(r.absolute_time || Date.now());
-      return ['日','一','二','三','四','五','六'][d.getDay()];
-    }
-    return 'Unknown';
-  }
-
-  function renderTrendChart(records) {
-    const container = document.getElementById('chart-trend');
-    if(records.length === 0) {
-      container.innerHTML = '<div class="empty-state">暂无数据</div>';
-      return;
-    }
-    const dates = {};
-    records.forEach(r => {
-      const d = (r.absolute_time || '').split(' ')[0] || 'Unknown';
-      if(!dates[d]) dates[d] = 0;
-      dates[d]++;
-    });
-    const sorted = Object.keys(dates).sort();
-    const maxVal = Math.max(...sorted.map(d => dates[d]), 1);
-
-    let html = '<div class="css-chart">';
-    sorted.forEach(d => {
-      const pct = (dates[d] / maxVal) * 100;
-      html += `
-        <div class="css-bar-container" title="${escapeHtml(d)}: ${dates[d]}">
-          <div class="css-bar-group">
-            <div class="css-bar" style="height: ${pct}%; background: #3b82f6;"></div>
-          </div>
-          <div class="css-label">${escapeHtml(d.substring(5))}</div>
-        </div>
-      `;
-    });
-    html += '</div>';
-    container.innerHTML = html;
-  }
-
-  function renderGroupedChart(records, groupBy) {
-    const container = document.getElementById('chart-grouped');
-    if(records.length === 0) {
-      container.innerHTML = '<div class="empty-state">暂无数据</div>';
-      return;
-    }
-
-    const groups = {};
-    if(groupBy === 'rune') {
-      records.forEach(r => {
-        (r.drops || []).forEach(d => {
-          const k = getGroupKey(r, groupBy, d);
-          if(!groups[k]) groups[k] = { runs: 0, drops: 0 };
-          groups[k].drops++;
-        });
-      });
-    } else {
-      records.forEach(r => {
-        const k = getGroupKey(r, groupBy);
-        if(!groups[k]) groups[k] = { runs: 0, drops: 0 };
-        groups[k].runs++;
-        groups[k].drops += (r.drops || []).length;
-      });
-    }
-
-    const sorted = Object.keys(groups).sort((a,b) => {
-      if(groupBy === 'rune') return groups[b].drops - groups[a].drops;
-      return groups[b].runs - groups[a].runs;
-    }).slice(0, 20);
-
-    if(sorted.length === 0) {
-      container.innerHTML = '<div class="empty-state">暂无数据</div>';
-      return;
-    }
-
-    const maxRuns = Math.max(...sorted.map(k => groups[k].runs), 1);
-    const maxDrops = Math.max(...sorted.map(k => groups[k].drops), 1);
-
-    let html = '<div class="css-chart">';
-    sorted.forEach(k => {
-      const rPct = (groups[k].runs / maxRuns) * 100;
-      const dPct = (groups[k].drops / maxDrops) * 100;
-      let bars = '';
-      if(groupBy === 'rune') {
-        bars = `<div class="css-bar" style="height: ${dPct}%; background: #10b981;" title="掉落: ${groups[k].drops}"></div>`;
-      } else {
-        bars = `
-          <div class="css-bar" style="height: ${rPct}%; background: #3b82f6;" title="运行: ${groups[k].runs}"></div>
-          <div class="css-bar" style="height: ${dPct}%; background: #10b981;" title="掉落: ${groups[k].drops}"></div>
-        `;
-      }
-      html += `
-        <div class="css-bar-container" title="${escapeHtml(k)}">
-          <div class="css-bar-group">${bars}</div>
-          <div class="css-label">${escapeHtml(k)}</div>
-        </div>
-      `;
-    });
-    html += '</div>';
-    container.innerHTML = html;
-  }
-
-  function renderRunesChart(records) {
-    const container = document.getElementById('chart-runes');
-    let totalDrops = 0;
-    const counts = {};
-    records.forEach(r => {
-      (r.drops || []).forEach(d => {
-        const n = d.rune_name || 'Unknown';
-        counts[n] = (counts[n] || 0) + 1;
-        totalDrops++;
-      });
-    });
-    if(totalDrops === 0) {
-      container.innerHTML = '<div class="empty-state">暂无数据</div>';
-      return;
-    }
-    const sorted = Object.keys(counts).sort((a,b) => counts[b] - counts[a]).slice(0, 30);
-    const maxVal = Math.max(...sorted.map(k => counts[k]), 1);
-
-    let html = '<div class="css-chart-horiz">';
-    sorted.forEach(k => {
-      const pct = (counts[k] / maxVal) * 100;
-      html += `
-        <div class="css-bar-row">
-          <div class="css-row-label" title="${escapeHtml(k)}">${escapeHtml(k)}</div>
-          <div class="css-row-bar-bg">
-            <div class="css-row-bar" style="width: ${pct}%; background: #8b5cf6;"></div>
-          </div>
-          <div class="css-row-val">${counts[k]}</div>
-        </div>
-      `;
-    });
-    html += '</div>';
-    container.innerHTML = html;
-  }
-
-  function renderRecords() {
-    const search = document.getElementById('records-search').value.toLowerCase();
-    const tbody = document.querySelector('#records-table tbody');
-    tbody.innerHTML = '';
-
-    if(STATE.records.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="7" style="text-align:center; color:var(--text-secondary); padding:2rem;">暂无数据</td></tr>';
-      return;
-    }
-
-    const filtered = STATE.records.filter(r => {
-      if(!search) return true;
-      const t = search;
-      if(r.character_name?.toLowerCase().includes(t)) return true;
-      if(r.scene_name?.toLowerCase().includes(t)) return true;
-      if(r.drops?.some(d => d.rune_name?.toLowerCase().includes(t))) return true;
-      return false;
-    }).sort((a,b) => (b.id||0) - (a.id||0)).slice(0, 100);
-
-    if(filtered.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="7" style="text-align:center; color:var(--text-secondary); padding:2rem;">无匹配记录</td></tr>';
-      return;
-    }
-
-    filtered.forEach(r => {
-      const tr = document.createElement('tr');
-      const tdId = document.createElement('td'); tdId.textContent = r.id; tr.appendChild(tdId);
-      const tdTime = document.createElement('td'); tdTime.textContent = r.absolute_time; tr.appendChild(tdTime);
-      const tdChar = document.createElement('td'); tdChar.textContent = r.character_name; tr.appendChild(tdChar);
-
-      const tdScene = document.createElement('td');
-      const spanScene = document.createElement('span');
-      spanScene.className = 'scene-rename';
-      spanScene.setAttribute('data-id', r.id);
-      spanScene.textContent = r.scene_name;
-      tdScene.appendChild(spanScene);
-      tr.appendChild(tdScene);
-
-      const tdTimer = document.createElement('td'); tdTimer.textContent = (r.timer_seconds||0).toFixed(1); tr.appendChild(tdTimer);
-
-      const tdDrops = document.createElement('td');
-      (r.drops || []).forEach((d, idx) => {
-        const spanDrop = document.createElement('span');
-        spanDrop.className = 'tag tag-rune';
-        spanDrop.textContent = `#${d.rune_number} ${d.rune_name} `;
-
-        const delBtn = document.createElement('span');
-        delBtn.className = 'tag-rune-del';
-        delBtn.setAttribute('data-rid', r.id);
-        delBtn.setAttribute('data-didx', idx);
-        delBtn.textContent = '×';
-        spanDrop.appendChild(delBtn);
-
-        tdDrops.appendChild(spanDrop);
-      });
-      tr.appendChild(tdDrops);
-
-      const tdAction = document.createElement('td');
-      const btnDel = document.createElement('button');
-      btnDel.className = 'btn btn-danger btn-delete-record';
-      btnDel.setAttribute('data-id', r.id);
-      btnDel.textContent = '删除';
-      tdAction.appendChild(btnDel);
-      tr.appendChild(tdAction);
-
-      tbody.appendChild(tr);
-    });
-  }
-  document.getElementById('records-search').addEventListener('input', renderRecords);
-
-  const apiBase = `http://127.0.0.1:${STATS_API_PORT}`;
-  async function fetchRecords() {
-    try {
-      const res = await fetch(`${apiBase}/api/records`);
-      if(res.ok) {
-        const data = await res.json();
-        if(data && data.records) { STATE.records = data.records; initData(); }
-      }
-    } catch(e) { /* silent fail or ui hint */ }
-  }
-  document.getElementById('btn-refresh').addEventListener('click', fetchRecords);
-
-  // Event Delegation
-  document.addEventListener('click', async (e) => {
-    if(e.target.classList.contains('btn-delete-record')) {
-      const id = e.target.getAttribute('data-id');
-      if(!confirm(`删除 ID ${id}?`)) return;
-      try {
-        if((await fetch(`${apiBase}/api/records/${id}`, {method:'DELETE'})).ok) fetchRecords();
-      } catch(err) {}
-    } else if(e.target.classList.contains('tag-rune-del')) {
-      const rid = e.target.getAttribute('data-rid');
-      const didx = e.target.getAttribute('data-didx');
-      if(!confirm('删除此掉落?')) return;
-      try {
-        if((await fetch(`${apiBase}/api/records/${rid}/drops/${didx}`, {method:'DELETE'})).ok) fetchRecords();
-      } catch(err) {}
-    } else if(e.target.classList.contains('scene-rename')) {
-      const id = e.target.getAttribute('data-id');
-      const cname = e.target.textContent;
-      const n = prompt('重命名场景:', cname);
-      if(n && n !== cname) {
-        try {
-          if((await fetch(`${apiBase}/api/records/${id}/rename?to=${encodeURIComponent(n)}`, {method:'POST'})).ok) fetchRecords();
-        } catch(err) {}
-      }
-    }
-  });
-
-  document.getElementById('btn-batch-rename-scene').addEventListener('click', async () => {
-    const f = prompt('原名:'); if(!f) return;
-    const t = prompt('新名:'); if(!t || f===t) return;
-    try {
-      if((await fetch(`${apiBase}/api/scenes/rename?from=${encodeURIComponent(f)}&to=${encodeURIComponent(t)}`, {method:'POST'})).ok) fetchRecords();
-    } catch(e) {}
-  });
-
-  document.getElementById('btn-export-csv').addEventListener('click', () => {
-    let csv = '\uFEFFID,时间,角色,场景,耗时(s),掉落物品\n';
-    STATE.records.forEach(r => {
-      const d = r.drops ? r.drops.map(x=>x.rune_name).join(';') : '';
-      csv += [r.id, r.absolute_time||'', r.character_name||'', r.scene_name||'', r.timer_seconds||0, d].map(v=>`"${String(v).replace(/"/g,'""')}"`).join(',') + '\n';
-    });
-    const blob = new Blob([csv], {type: 'text/csv;charset=utf-8;'});
-    const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = 'stats.csv';
-    a.click();
-  });
-  initData();
-</script>
+    </section>
+    <section class="view" id="view-records" role="tabpanel" hidden><section class="panel"><div class="records-toolbar"><input class="control records-search" id="records-search" type="search" placeholder="搜索时间、角色、场景或符文…"><select class="control metric-select" id="records-sort"><option value="newest">时间：新到旧</option><option value="oldest">时间：旧到新</option><option value="duration-desc">耗时：长到短</option><option value="duration-asc">耗时：短到长</option><option value="drops-desc">掉落：多到少</option></select><button class="button" type="button" id="export-csv">导出筛选 CSV</button><button class="button" type="button" id="export-json">导出筛选 JSON</button></div><div class="data-table-wrap" id="records-table"></div><div class="pagination"><span class="pagination-state" id="pagination-state"></span><div><button class="button button-small" type="button" id="page-prev">上一页</button> <button class="button button-small" type="button" id="page-next">下一页</button></div></div></section></section>
+    <details class="methodology"><summary>统计口径与数据边界</summary><div class="methodology-content"><ul><li><strong>一场：</strong>OCR 从一个非城镇场景切换到其他场景或返回城镇时保存一条 <code>scene_records</code>；尚未结束的计时不计入。</li><li><strong>耗时：</strong>该场景计时起止之间的秒数。平均值、P90、最佳耗时只基于当前筛选范围内耗时大于 0 的记录。</li><li><strong>掉落：</strong><code>drops_json</code> 数组中的每个元素代表一次独立符文掉落；同一场、同一符文多次掉落分别计数。</li><li><strong>高级符文：</strong>统一按符文编号 ≥24（伊斯特及以上）统计；“命中率”指至少有一次对应掉落的场次 ÷ 总场次。</li><li><strong>命中间隔：</strong>筛选记录按时间排序后，相邻两个高级符文命中场之间相隔的场次数；至少两次命中才计算平均值。</li><li><strong>截图：</strong>只统计带 <code>screenshot_path</code> 的掉落；本地文件被清理后记录仍保留，但预览可能失效。</li></ul></div></details>
+  </main>
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  <script>
+    const RAW_STATS_DATA={{STATS_DATA}};const API_PORT={{STATS_API_PORT}};const API_BASE=`http://127.0.0.1:${API_PORT}`;const HIGH_RUNE_MIN=24;const PAGE_SIZE=50;
+    const RUNE_NAMES=["艾尔","艾德","特尔","那夫","爱斯","伊司","塔尔","拉尔","欧特","书尔","安姆","索尔","夏","多尔","海尔","艾欧","卢姆","科","法尔","蓝姆","普尔","乌姆","马尔","伊斯特","古尔","伐克斯","欧姆","罗","瑟","贝","乔","查姆","萨德"];const WEEKDAYS=["周一","周二","周三","周四","周五","周六","周日"];
+    const state={records:Array.isArray(RAW_STATS_DATA.records)?RAW_STATS_DATA.records:[],filtered:[],activeView:"overview",page:1};const $=s=>document.querySelector(s),$$=s=>Array.from(document.querySelectorAll(s)),number=v=>Number.isFinite(Number(v))?Number(v):0;
+    function escapeHtml(v){return String(v??"").replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;").replaceAll('"',"&quot;").replaceAll("'","&#039;")}
+    function parseRecordDate(v){const t=String(v||""),m=t.match(/^(\d{4})\/(\d{2})\/(\d{2})\/(\d{2}):(\d{2}):(\d{2})$/);if(m){const[,y,mo,d,h,mi,s]=m.map(Number);return new Date(y,mo-1,d,h,mi,s)}const f=new Date(t);return Number.isNaN(f.getTime())?null:f}
+    function formatDate(v,compact=false){const d=parseRecordDate(v);if(!d)return String(v||"—");const p=n=>String(n).padStart(2,"0"),date=`${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())}`;return compact?date:`${date} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`}
+    function formatDuration(s){const t=Math.max(0,number(s));if(t<60)return`${t.toFixed(t<10?1:0)} 秒`;const m=Math.floor(t/60),r=Math.round(t%60);if(m<60)return`${m}分 ${r}秒`;return`${Math.floor(m/60)}时 ${m%60}分`}
+    function formatRate(v){return`${(number(v)*100).toFixed(v>=.1?1:2)}%`}function quantile(values,q){const s=values.map(number).filter(v=>v>0).sort((a,b)=>a-b);if(!s.length)return 0;const p=(s.length-1)*q,b=Math.floor(p),r=p-b;return s[b+1]===undefined?s[b]:s[b]+r*(s[b+1]-s[b])}
+    const getDrops=r=>Array.isArray(r.drops)?r.drops:[],isHighRune=d=>number(d.rune_number)>=HIGH_RUNE_MIN;
+    function safeScreenshotUrl(path){const n=String(path||"").replaceAll("\\","/");if(!n||n.includes("..")||/^[a-z]+:/i.test(n))return"";return encodeURI(n.replace(/^\.\//,""))}
+    function showToast(message){const t=$("#toast");t.textContent=message;t.classList.add("show");clearTimeout(showToast.timer);showToast.timer=setTimeout(()=>t.classList.remove("show"),2400)}
+    function downloadFile(name,content,type){const url=URL.createObjectURL(new Blob([content],{type})),a=document.createElement("a");a.href=url;a.download=name;a.click();setTimeout(()=>URL.revokeObjectURL(url),0)}
+    function populateSelects(){const pc=$("#filter-character").value,ps=$("#filter-scene").value,chars=[...new Set(state.records.map(r=>r.character_name).filter(Boolean))].sort((a,b)=>a.localeCompare(b,"zh-CN")),scenes=[...new Set(state.records.map(r=>r.scene_name).filter(Boolean))].sort((a,b)=>a.localeCompare(b,"zh-CN"));$("#filter-character").innerHTML='<option value="">全部角色</option>'+chars.map(n=>`<option value="${escapeHtml(n)}">${escapeHtml(n)}</option>`).join("");$("#filter-scene").innerHTML='<option value="">全部场景</option>'+scenes.map(n=>`<option value="${escapeHtml(n)}">${escapeHtml(n)}</option>`).join("");$("#filter-rune").innerHTML='<option value="">全部符文</option>'+RUNE_NAMES.map((n,i)=>`<option value="${i+1}">#${i+1} ${n}</option>`).join("");if(chars.includes(pc))$("#filter-character").value=pc;if(scenes.includes(ps))$("#filter-scene").value=ps}
+    function cutoffForPeriod(p){if(p==="all")return null;const n=new Date(),today=new Date(n.getFullYear(),n.getMonth(),n.getDate());if(p==="today")return today;return new Date(today.getTime()-Math.max(0,Number(p)-1)*864e5)}
+    function applyFilters(){const period=$("#filter-period").value,char=$("#filter-character").value,scene=$("#filter-scene").value,dropMode=$("#filter-drop").value,rune=number($("#filter-rune").value),cutoff=cutoffForPeriod(period);state.filtered=state.records.filter(r=>{const date=parseRecordDate(r.absolute_time),drops=getDrops(r);if(cutoff&&(!date||date<cutoff))return false;if(char&&r.character_name!==char)return false;if(scene&&r.scene_name!==scene)return false;if(dropMode==="any"&&!drops.length)return false;if(dropMode==="none"&&drops.length)return false;if(dropMode==="high"&&!drops.some(isHighRune))return false;if(dropMode==="screenshot"&&!drops.some(d=>d.screenshot_path))return false;if(rune&&!drops.some(d=>number(d.rune_number)===rune))return false;return true});state.page=1;const dc=state.filtered.reduce((s,r)=>s+getDrops(r).length,0);$("#filter-summary").textContent=`${state.filtered.length.toLocaleString()} / ${state.records.length.toLocaleString()} 场 · ${dc.toLocaleString()} 次符文掉落`;renderAll()}
+    function summarize(records){const durations=records.map(r=>number(r.timer_seconds)).filter(v=>v>0),drops=records.flatMap(getDrops),highDrops=drops.filter(isHighRune),runsWithDrop=records.filter(r=>getDrops(r).length).length,runsWithHigh=records.filter(r=>getDrops(r).some(isHighRune)).length,totalSeconds=durations.reduce((s,v)=>s+v,0);return{runs:records.length,durations,totalSeconds,average:durations.length?totalSeconds/durations.length:0,median:quantile(durations,.5),best:durations.length?Math.min(...durations):0,p90:quantile(durations,.9),drops,highDrops,runsWithDrop,runsWithHigh,screenshots:drops.filter(d=>d.screenshot_path).length}}
+    function renderKpis(){const s=summarize(state.filtered),cells=[["场次记录",s.runs.toLocaleString(),`累计 ${formatDuration(s.totalSeconds)}`],["平均耗时",s.average?formatDuration(s.average):"—",`中位数 ${s.median?formatDuration(s.median):"—"}`],["最佳耗时",s.best?formatDuration(s.best):"—",`P90 ${s.p90?formatDuration(s.p90):"—"}`],["符文掉落",s.drops.length.toLocaleString(),`${s.runs?(s.drops.length/s.runs*100).toFixed(1):"0"} 次 / 百场`],["高级符文",s.highDrops.length.toLocaleString(),`命中场次 ${formatRate(s.runs?s.runsWithHigh/s.runs:0)}`],["有掉落场次",formatRate(s.runs?s.runsWithDrop/s.runs:0),`${s.screenshots} 张截图留存`]];$("#kpi-strip").innerHTML=cells.map(([l,v,n])=>`<div class="kpi"><div class="kpi-label">${l}</div><div class="kpi-value">${v}</div><div class="kpi-note">${n}</div></div>`).join("")}
+    function dailySeries(records){const groups=new Map;records.forEach(r=>{const d=parseRecordDate(r.absolute_time);if(!d)return;const key=formatDate(r.absolute_time,true);if(!groups.has(key))groups.set(key,{key,runs:0,duration:0,durationCount:0,drops:0,high:0});const g=groups.get(key);g.runs++;const sec=number(r.timer_seconds);if(sec>0){g.duration+=sec;g.durationCount++}g.drops+=getDrops(r).length;g.high+=getDrops(r).filter(isHighRune).length});return[...groups.values()].sort((a,b)=>a.key.localeCompare(b.key))}
+    function renderTrend(){const metric=$("#trend-metric").value,series=dailySeries(state.filtered),c=$("#trend-chart");if(!series.length){c.innerHTML='<div class="empty">当前筛选范围没有可绘制的日期记录</div>';return}const values=series.map(i=>metric==="avg"?(i.durationCount?i.duration/i.durationCount:0):i[metric]),max=Math.max(...values,1),w=Math.max(760,series.length*32),h=250,p={l:44,r:14,t:14,b:34},pw=w-p.l-p.r,ph=h-p.t-p.b,step=pw/series.length,y=v=>p.t+ph-v/max*ph,label=metric==="avg"?"平均耗时（秒）":metric==="runs"?"场次":metric==="drops"?"符文":"高级符文";let svg=`<svg viewBox="0 0 ${w} ${h}" role="img" aria-label="${label}按日趋势">`;for(let g=0;g<=4;g++){const val=max*(4-g)/4,gy=p.t+ph*g/4;svg+=`<line class="chart-grid-line" x1="${p.l}" y1="${gy}" x2="${w-p.r}" y2="${gy}"/><text class="chart-label" x="${p.l-7}" y="${gy+3}" text-anchor="end">${metric==="avg"?val.toFixed(0):Math.round(val)}</text>`}if(metric==="avg"){const points=values.map((v,i)=>`${p.l+step*(i+.5)},${y(v)}`).join(" "),area=`${p.l+step*.5},${p.t+ph} ${points} ${p.l+step*(series.length-.5)},${p.t+ph}`;svg+=`<polygon class="chart-area" points="${area}"/><polyline class="chart-line" points="${points}"/>`;values.forEach((v,i)=>{const x=p.l+step*(i+.5);svg+=`<circle class="chart-point" cx="${x}" cy="${y(v)}" r="3"><title>${series[i].key} · ${formatDuration(v)}</title></circle>`})}else{const bw=Math.max(3,Math.min(20,step*.66));values.forEach((v,i)=>{const x=p.l+step*(i+.5)-bw/2,by=y(v);svg+=`<rect class="chart-bar" x="${x}" y="${by}" width="${bw}" height="${p.t+ph-by}" rx="2"><title>${series[i].key} · ${v} ${label}</title></rect>`})}const every=Math.max(1,Math.ceil(series.length/8));series.forEach((item,i)=>{if(i%every&&i!==series.length-1)return;svg+=`<text class="chart-label" x="${p.l+step*(i+.5)}" y="${h-10}" text-anchor="middle">${item.key.slice(5)}</text>`});c.innerHTML=svg+"</svg>"}
+    function groupedStats(records,key){const groups=new Map;records.forEach(r=>{const name=r[key]||"未知";if(!groups.has(name))groups.set(name,[]);groups.get(name).push(r)});return[...groups.entries()].map(([name,items])=>({name,items,summary:summarize(items)}))}
+    function renderSceneTable(){const groups=groupedStats(state.filtered,"scene_name").sort((a,b)=>b.summary.runs-a.summary.runs),c=$("#scene-table");if(!groups.length){c.innerHTML='<div class="empty">暂无场景统计</div>';return}const max=Math.max(...groups.map(g=>g.summary.runs),1);c.innerHTML=`<table><thead><tr><th>场景</th><th class="number">场次</th><th class="number">平均</th><th class="number">P90</th><th class="number">符文/百场</th><th></th></tr></thead><tbody>${groups.map(g=>{const s=g.summary;return`<tr><td class="scene-name" title="${escapeHtml(g.name)}">${escapeHtml(g.name)}</td><td class="number"><span class="inline-meter"><span class="inline-meter-track"><span class="inline-meter-fill" style="width:${s.runs/max*100}%"></span></span>${s.runs}</span></td><td class="number">${s.average?formatDuration(s.average):"—"}</td><td class="number">${s.p90?formatDuration(s.p90):"—"}</td><td class="number">${s.runs?(s.drops.length/s.runs*100).toFixed(1):"0"}</td><td><button class="button button-small" data-action="rename-scene" data-scene="${escapeHtml(g.name)}">统一命名</button></td></tr>`}).join("")}</tbody></table>`}
+    function renderCharacterComparison(){const groups=groupedStats(state.filtered,"character_name").sort((a,b)=>b.summary.runs-a.summary.runs),c=$("#character-comparison");if(!groups.length){c.innerHTML='<div class="empty">暂无角色统计</div>';return}const max=Math.max(...groups.map(g=>g.summary.runs),1);c.innerHTML=`<div class="comparison-list">${groups.slice(0,12).map(g=>`<div class="comparison-row"><div class="comparison-name" title="${escapeHtml(g.name)}">${escapeHtml(g.name)}</div><div class="comparison-track"><div class="comparison-fill" style="width:${g.summary.runs/max*100}%"></div></div><div class="comparison-value">${g.summary.runs} 场 · ${g.summary.average?formatDuration(g.summary.average):"—"}</div></div>`).join("")}</div>`}
+    function renderActivityHeatmap(){const matrix=Array.from({length:7},()=>Array(24).fill(0));state.filtered.forEach(r=>{const d=parseRecordDate(r.absolute_time);if(d)matrix[(d.getDay()+6)%7][d.getHours()]++});const max=Math.max(1,...matrix.flat());let html='<div class="heatmap"><span></span>';for(let h=0;h<24;h++)html+=`<span class="heatmap-hour">${h%3===0?String(h).padStart(2,"0"):""}</span>`;matrix.forEach((row,day)=>{html+=`<span class="heatmap-label">${WEEKDAYS[day]}</span>`;row.forEach((v,h)=>{const strength=v?18+v/max*72:0;html+=`<span class="heatmap-cell" style="background:${v?`color-mix(in srgb,var(--info) ${Math.round(strength)}%,var(--surface-active))`:"var(--surface-active)"}" title="${WEEKDAYS[day]} ${String(h).padStart(2,"0")}:00 · ${v} 场"></span>`})});$("#activity-heatmap").innerHTML=html+"</div>"}
+    function runeCounts(){const counts=Array(34).fill(0);state.filtered.forEach(r=>getDrops(r).forEach(d=>{const n=number(d.rune_number);if(n>=1&&n<=33)counts[n]++}));return counts}
+    function renderRunes(){const counts=runeCounts(),ranges=[["低阶 #1–15",1,15],["中阶 #16–23",16,23],["高阶 #24–29",24,29],["顶阶 #30–33",30,33]];$("#rune-summary").innerHTML=ranges.map(([l,s,e])=>`<div class="rune-tier"><span>${l}</span><strong>${counts.slice(s,e+1).reduce((a,b)=>a+b,0).toLocaleString()}</strong></div>`).join("");const active=number($("#filter-rune").value);$("#rune-matrix").innerHTML=RUNE_NAMES.map((name,i)=>{const rune=i+1,tier=rune>=30?"elite":rune>=24?"high":"normal";return`<button class="rune-cell" type="button" data-rune="${rune}" data-tier="${tier}" data-active="${active===rune}"><div class="rune-number">#${rune}</div><div class="rune-name">${name}</div><div class="rune-count">${counts[rune]} 次</div></button>`}).join("");const ranked=RUNE_NAMES.map((name,i)=>({name,rune:i+1,count:counts[i+1]})).filter(i=>i.count).sort((a,b)=>b.count-a.count||b.rune-a.rune),max=Math.max(1,...ranked.map(i=>i.count));$("#rune-ranking").innerHTML=ranked.length?`<div class="comparison-list">${ranked.slice(0,14).map(i=>`<div class="comparison-row"><div class="comparison-name">#${i.rune} ${i.name}</div><div class="comparison-track"><div class="comparison-fill" style="width:${i.count/max*100}%;background:${i.rune>=24?"var(--warning)":"var(--info)"}"></div></div><div class="comparison-value">${i.count}</div></div>`).join("")}</div>`:'<div class="empty">当前范围没有符文掉落</div>';const summary=summarize(state.filtered),ordered=state.filtered.slice().sort((a,b)=>(parseRecordDate(a.absolute_time)?.getTime()||0)-(parseRecordDate(b.absolute_time)?.getTime()||0)),hitIndexes=[];ordered.forEach((r,index)=>{if(getDrops(r).some(isHighRune))hitIndexes.push(index)});const intervals=hitIndexes.slice(1).map((index,i)=>index-hitIndexes[i]),avgInterval=intervals.length?intervals.reduce((a,b)=>a+b,0)/intervals.length:0;$("#high-rune-insights").innerHTML=`<div class="comparison-list"><div class="comparison-row"><div class="comparison-name">高级符文总数</div><div></div><div class="comparison-value">${summary.highDrops.length}</div></div><div class="comparison-row"><div class="comparison-name">命中场次</div><div></div><div class="comparison-value">${summary.runsWithHigh} / ${summary.runs}</div></div><div class="comparison-row"><div class="comparison-name">场次命中率</div><div></div><div class="comparison-value">${formatRate(summary.runs?summary.runsWithHigh/summary.runs:0)}</div></div><div class="comparison-row"><div class="comparison-name">平均命中间隔</div><div></div><div class="comparison-value">${avgInterval?`${avgInterval.toFixed(1)} 场`:"—"}</div></div></div>`;const shots=[];state.filtered.forEach(r=>getDrops(r).forEach(d=>{const url=safeScreenshotUrl(d.screenshot_path);if(url)shots.push({r,d,url})}));$("#screenshot-gallery").innerHTML=shots.length?shots.reverse().map(({r,d,url})=>`<a class="gallery-item" href="${escapeHtml(url)}" target="_blank" rel="noreferrer"><img src="${escapeHtml(url)}" alt="#${number(d.rune_number)} ${escapeHtml(d.rune_name)} 掉落截图" loading="lazy"><div class="gallery-caption"><strong>#${number(d.rune_number)} ${escapeHtml(d.rune_name)}</strong><span>${escapeHtml(r.scene_name)} · ${formatDate(r.absolute_time)}</span></div></a>`).join(""):'<div class="empty">当前范围没有可用的掉落截图</div>'}
+    function recordSearchResults(){const q=$("#records-search").value.trim().toLocaleLowerCase("zh-CN"),results=state.filtered.filter(r=>!q||[r.absolute_time,r.character_name,r.scene_name,...getDrops(r).flatMap(d=>[d.rune_name,d.rune_name_en,`#${d.rune_number}`])].join(" ").toLocaleLowerCase("zh-CN").includes(q)),sort=$("#records-sort").value;results.sort((a,b)=>sort==="oldest"?(parseRecordDate(a.absolute_time)?.getTime()||0)-(parseRecordDate(b.absolute_time)?.getTime()||0):sort==="duration-desc"?number(b.timer_seconds)-number(a.timer_seconds):sort==="duration-asc"?number(a.timer_seconds)-number(b.timer_seconds):sort==="drops-desc"?getDrops(b).length-getDrops(a).length:(parseRecordDate(b.absolute_time)?.getTime()||0)-(parseRecordDate(a.absolute_time)?.getTime()||0));return results}
+    function renderRecords(){const records=recordSearchResults(),pages=Math.max(1,Math.ceil(records.length/PAGE_SIZE));state.page=Math.min(state.page,pages);const page=records.slice((state.page-1)*PAGE_SIZE,state.page*PAGE_SIZE),c=$("#records-table");c.innerHTML=!page.length?'<div class="empty">没有符合条件的原始记录</div>':`<table><thead><tr><th>时间</th><th>角色</th><th>场景</th><th class="number">耗时</th><th>掉落</th><th></th></tr></thead><tbody>${page.map(r=>`<tr><td class="subtle">${formatDate(r.absolute_time)}</td><td>${escapeHtml(r.character_name||"未知角色")}</td><td class="scene-name">${escapeHtml(r.scene_name||"未知场景")}</td><td class="number">${formatDuration(r.timer_seconds)}</td><td><div class="record-drops">${getDrops(r).length?getDrops(r).map((d,i)=>`<span class="drop-chip ${isHighRune(d)?"high":""}">#${number(d.rune_number)} ${escapeHtml(d.rune_name)}<button class="drop-delete" type="button" title="删除这次掉落" data-action="delete-drop" data-record-id="${r.id}" data-drop-index="${i}">×</button></span>`).join(""):'<span class="subtle">无</span>'}</div></td><td><button class="button button-small" type="button" data-action="rename-record" data-record-id="${r.id}" data-scene="${escapeHtml(r.scene_name)}">改名</button> <button class="button button-small button-danger" type="button" data-action="delete-record" data-record-id="${r.id}">删除</button></td></tr>`).join("")}</tbody></table>`;$("#pagination-state").textContent=`${records.length.toLocaleString()} 条 · 第 ${state.page} / ${pages} 页`;$("#page-prev").disabled=state.page<=1;$("#page-next").disabled=state.page>=pages}
+    function renderAll(){renderKpis();renderTrend();renderSceneTable();renderCharacterComparison();renderActivityHeatmap();renderRunes();renderRecords()}
+    async function fetchRecords(){const sync=$("#sync-state");sync.textContent="正在刷新…";try{const response=await fetch(`${API_BASE}/api/records`);if(!response.ok)throw new Error(`HTTP ${response.status}`);const data=await response.json();state.records=Array.isArray(data.records)?data.records:[];populateSelects();applyFilters();sync.textContent=`已同步 ${new Date().toLocaleTimeString("zh-CN",{hour:"2-digit",minute:"2-digit"})}`;showToast("统计数据已刷新")}catch(error){sync.textContent="刷新失败，显示打开时快照";showToast(`刷新失败：${error}`)}}
+    async function apiMutation(url,options,message){const response=await fetch(`${API_BASE}${url}`,options);if(!response.ok)throw new Error(`HTTP ${response.status}`);await fetchRecords();showToast(message)}function switchView(view){state.activeView=view;$$('.tab').forEach(t=>t.setAttribute("aria-selected",String(t.dataset.view===view)));$$('.view').forEach(p=>p.hidden=p.id!==`view-${view}`)}
+    $$('.tab').forEach(t=>t.addEventListener("click",()=>switchView(t.dataset.view)));["#filter-period","#filter-character","#filter-scene","#filter-drop","#filter-rune"].forEach(s=>$(s).addEventListener("change",applyFilters));$("#trend-metric").addEventListener("change",renderTrend);$("#records-search").addEventListener("input",()=>{state.page=1;renderRecords()});$("#records-sort").addEventListener("change",()=>{state.page=1;renderRecords()});$("#refresh-data").addEventListener("click",fetchRecords);$("#reset-filters").addEventListener("click",()=>{$("#filter-period").value="all";$("#filter-character").value="";$("#filter-scene").value="";$("#filter-drop").value="all";$("#filter-rune").value="";applyFilters()});$("#page-prev").addEventListener("click",()=>{if(state.page>1){state.page--;renderRecords()}});$("#page-next").addEventListener("click",()=>{state.page++;renderRecords()});
+    $("#rune-matrix").addEventListener("click",e=>{const cell=e.target.closest("[data-rune]");if(!cell)return;$("#filter-rune").value=$("#filter-rune").value===cell.dataset.rune?"":cell.dataset.rune;applyFilters()});
+    $("#scene-table").addEventListener("click",async e=>{const b=e.target.closest('[data-action="rename-scene"]');if(!b)return;const from=b.dataset.scene,to=prompt(`将所有“${from}”记录统一命名为：`,from);if(!to||to.trim()===from)return;try{await apiMutation(`/api/scenes/rename?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to.trim())}`,{method:"POST"},"场景名称已统一更新")}catch(error){showToast(`重命名失败：${error}`)}});
+    $("#records-table").addEventListener("click",async e=>{const b=e.target.closest("[data-action]");if(!b)return;const action=b.dataset.action,id=b.dataset.recordId;try{if(action==="delete-record"){if(!confirm("确定删除整条场景记录？此操作不可恢复。"))return;await apiMutation(`/api/records/${id}`,{method:"DELETE"},"记录已删除")}else if(action==="delete-drop"){if(!confirm("确定从该场记录中删除这次符文掉落？"))return;await apiMutation(`/api/records/${id}/drops/${b.dataset.dropIndex}`,{method:"DELETE"},"掉落记录已删除")}else if(action==="rename-record"){const current=b.dataset.scene,next=prompt("修改这一条记录的场景名称：",current);if(!next||next.trim()===current)return;await apiMutation(`/api/records/${id}/rename?to=${encodeURIComponent(next.trim())}`,{method:"POST"},"记录名称已更新")}}catch(error){showToast(`操作失败：${error}`)}});
+    $("#export-csv").addEventListener("click",()=>{const rows=[["id","time","character","scene","seconds","rune_number","rune_name","rune_name_en","screenshot_path"]];state.filtered.forEach(r=>{const drops=getDrops(r);if(!drops.length)rows.push([r.id,r.absolute_time,r.character_name,r.scene_name,r.timer_seconds,"","","",""]);drops.forEach(d=>rows.push([r.id,r.absolute_time,r.character_name,r.scene_name,r.timer_seconds,d.rune_number,d.rune_name,d.rune_name_en||"",d.screenshot_path||""]))});const csv="\uFEFF"+rows.map(row=>row.map(v=>`"${String(v??"").replaceAll('"','""')}"`).join(",")).join("\r\n");downloadFile(`d2rhub-stats-${new Date().toISOString().slice(0,10)}.csv`,csv,"text/csv;charset=utf-8");showToast(`已导出 ${state.filtered.length} 场记录`)});$("#export-json").addEventListener("click",()=>{downloadFile(`d2rhub-stats-${new Date().toISOString().slice(0,10)}.json`,JSON.stringify({records:state.filtered},null,2),"application/json;charset=utf-8");showToast(`已导出 ${state.filtered.length} 场记录`)});
+    function applyTheme(theme){const normalized=theme==="light"?"light":"onyx";document.documentElement.dataset.theme=normalized;document.documentElement.style.colorScheme=normalized==="onyx"?"dark":"light";$("#theme-toggle").textContent=normalized==="onyx"?"浅色":"深色";}$("#theme-toggle").addEventListener("click",()=>applyTheme(document.documentElement.dataset.theme==="onyx"?"light":"onyx"));applyTheme(document.documentElement.dataset.theme);populateSelects();applyFilters();
+  </script>
 </body>
 </html>

--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -3,314 +3,515 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>D2RHub 使用指南</title>
+<meta name="color-scheme" content="dark light">
+<title>D2RHub v0.8 使用手册</title>
 <style>
   :root {
-    --bg-main: #0a0a0b;
-    --bg-surface: #121214;
-    --bg-panel: #18181b;
-    --border: rgba(255, 255, 255, 0.08);
-    --border-hover: rgba(255, 255, 255, 0.15);
-    --text-primary: #ededef;
-    --text-secondary: #a1a1aa;
-    --accent: #3b82f6;
-    --accent-hover: #60a5fa;
-    --radius-sm: 6px;
-    --radius-md: 8px;
-    --radius-lg: 12px;
+    --bg: #090a0c;
+    --surface: #101216;
+    --surface-raised: #171a20;
+    --surface-soft: #1d2129;
+    --border: rgba(255,255,255,.09);
+    --border-strong: rgba(255,255,255,.16);
+    --text: #f4f3ef;
+    --muted: #aaaeb8;
+    --faint: #757b88;
+    --accent: #d5a85a;
+    --accent-soft: rgba(213,168,90,.12);
+    --blue: #77a8ff;
+    --green: #65c494;
+    --red: #ef7f7f;
+    --shadow: 0 22px 70px rgba(0,0,0,.28);
   }
+
   [data-theme="light"] {
-    --bg-main: #f4f4f5;
-    --bg-surface: #ffffff;
-    --bg-panel: #fafafa;
-    --border: rgba(0, 0, 0, 0.1);
-    --border-hover: rgba(0, 0, 0, 0.2);
-    --text-primary: #18181b;
-    --text-secondary: #52525b;
-    --accent: #2563eb;
-    --accent-hover: #3b82f6;
+    --bg: #f2f0eb;
+    --surface: #fbfaf7;
+    --surface-raised: #fff;
+    --surface-soft: #efede7;
+    --border: rgba(28,31,36,.10);
+    --border-strong: rgba(28,31,36,.18);
+    --text: #202226;
+    --muted: #5d626c;
+    --faint: #80858e;
+    --accent: #94661c;
+    --accent-soft: rgba(148,102,28,.10);
+    --blue: #356fc8;
+    --green: #247a50;
+    --red: #b33f3f;
+    --shadow: 0 20px 55px rgba(53,45,33,.10);
   }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; scroll-padding-top: 28px; }
   body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    background: var(--bg-main);
-    color: var(--text-primary);
-    line-height: 1.6;
-    display: flex;
-    height: 100vh;
-    overflow: hidden;
+    margin: 0;
+    min-height: 100vh;
+    background:
+      radial-gradient(circle at 80% -10%, var(--accent-soft), transparent 30rem),
+      var(--bg);
+    color: var(--text);
+    font: 15px/1.75 "Segoe UI", "Microsoft YaHei UI", system-ui, sans-serif;
   }
-
-  /* Sidebar */
-  .sidebar {
-    width: 240px;
-    background: var(--bg-surface);
-    border-right: 1px solid var(--border);
-    display: flex;
-    flex-direction: column;
-    padding: 1rem 0;
-    flex-shrink: 0;
-  }
-  .sidebar-header {
-    padding: 0 1.5rem 1rem;
-    font-size: 1.25rem;
-    font-weight: 600;
-    border-bottom: 1px solid var(--border);
-    margin-bottom: 1rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  .nav-menu {
-    flex: 1;
-    overflow-y: auto;
-    padding: 0 0.75rem;
-  }
-  .nav-item {
-    display: block;
-    padding: 0.5rem 0.75rem;
-    color: var(--text-secondary);
-    text-decoration: none;
-    border-radius: var(--radius-md);
-    margin-bottom: 0.25rem;
-    transition: all 0.2s;
-    font-size: 0.9rem;
-  }
-  .nav-item:hover {
-    background: var(--bg-panel);
-    color: var(--text-primary);
-  }
-  .nav-item.active {
-    background: var(--bg-panel);
-    color: var(--accent);
-    font-weight: 500;
-  }
-
-  /* Theme Toggle */
-  .theme-toggle {
-    background: transparent;
-    border: 1px solid var(--border);
-    color: var(--text-primary);
-    padding: 0.25rem 0.5rem;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    font-size: 0.8rem;
-  }
-
-  /* Main Content */
-  .main-content {
-    flex: 1;
-    overflow-y: auto;
-    padding: 2rem 3rem;
-    scroll-behavior: smooth;
-  }
-  .section {
-    margin-bottom: 3rem;
-    padding: 2rem;
-    background: var(--bg-surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-  }
-  .section h2 {
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-    color: var(--text-primary);
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 0.5rem;
-  }
-  .section h3 {
-    font-size: 1.1rem;
-    margin-top: 1.5rem;
-    margin-bottom: 0.5rem;
-    color: var(--text-primary);
-  }
-  .section p {
-    color: var(--text-secondary);
-    margin-bottom: 1rem;
-    font-size: 0.95rem;
-  }
-  .section ul {
-    list-style-type: disc;
-    margin-left: 1.5rem;
-    margin-bottom: 1rem;
-    color: var(--text-secondary);
-    font-size: 0.95rem;
-  }
-  .section li {
-    margin-bottom: 0.25rem;
-  }
+  button, input { font: inherit; }
+  button { color: inherit; }
+  a { color: var(--blue); text-decoration: none; }
+  a:hover { text-decoration: underline; }
   code {
-    background: var(--bg-panel);
-    padding: 0.2rem 0.4rem;
-    border-radius: var(--radius-sm);
-    font-family: monospace;
-    font-size: 0.85em;
+    padding: .12rem .36rem;
     border: 1px solid var(--border);
+    border-radius: 5px;
+    background: var(--surface-soft);
+    color: var(--text);
+    font: .88em Consolas, "SFMono-Regular", monospace;
+  }
+  kbd {
+    display: inline-block;
+    min-width: 1.7em;
+    padding: .05rem .38rem;
+    border: 1px solid var(--border-strong);
+    border-bottom-width: 2px;
+    border-radius: 5px;
+    background: var(--surface-raised);
+    text-align: center;
+    font: .82em Consolas, monospace;
   }
 
-  @media (max-width: 768px) {
-    body { flex-direction: column; }
-    .sidebar { width: 100%; height: auto; border-right: none; border-bottom: 1px solid var(--border); padding-bottom: 0; }
-    .nav-menu { display: flex; overflow-x: auto; padding: 0.5rem; }
-    .nav-item { white-space: nowrap; margin-bottom: 0; margin-right: 0.5rem; }
-    .main-content { padding: 1rem; }
-    .section { padding: 1.5rem; margin-bottom: 1.5rem; }
+  .shell { display: grid; grid-template-columns: 276px minmax(0, 1fr); min-height: 100vh; }
+  .sidebar {
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    padding: 26px 20px 20px;
+    border-right: 1px solid var(--border);
+    background: color-mix(in srgb, var(--surface) 94%, transparent);
+    backdrop-filter: blur(18px);
+    overflow-y: auto;
+  }
+  .brand { display: flex; align-items: center; gap: 12px; margin: 0 8px 24px; }
+  .brand-mark {
+    display: grid;
+    width: 38px;
+    height: 38px;
+    place-items: center;
+    border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+    border-radius: 10px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-weight: 800;
+  }
+  .brand strong { display: block; font-size: 17px; letter-spacing: .02em; }
+  .brand span { display: block; color: var(--faint); font-size: 11px; letter-spacing: .08em; }
+  .nav-title { margin: 17px 10px 7px; color: var(--faint); font-size: 10px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+  .nav-link {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    margin: 2px 0;
+    padding: 7px 10px;
+    border-radius: 7px;
+    color: var(--muted);
+    font-size: 13px;
+  }
+  .nav-link::before { content: ""; width: 5px; height: 5px; border-radius: 50%; background: var(--border-strong); }
+  .nav-link:hover { background: var(--surface-soft); color: var(--text); text-decoration: none; }
+  .nav-link.active { background: var(--accent-soft); color: var(--accent); font-weight: 650; }
+  .nav-link.active::before { background: var(--accent); box-shadow: 0 0 0 4px var(--accent-soft); }
+  .theme-button {
+    width: 100%;
+    margin-top: 20px;
+    padding: 8px 11px;
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    background: transparent;
+    cursor: pointer;
+    color: var(--muted);
+  }
+  .theme-button:hover { border-color: var(--border-strong); color: var(--text); }
+
+  main { width: min(100%, 1080px); padding: 54px 54px 100px; }
+  .hero { padding: 12px 0 48px; border-bottom: 1px solid var(--border); }
+  .eyebrow { margin: 0 0 9px; color: var(--accent); font-size: 12px; font-weight: 750; letter-spacing: .13em; text-transform: uppercase; }
+  h1 { margin: 0; max-width: 760px; font-size: clamp(35px, 5vw, 64px); line-height: 1.02; letter-spacing: -.045em; }
+  .lede { max-width: 720px; margin: 22px 0 0; color: var(--muted); font-size: 17px; }
+  .meta-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 24px; }
+  .badge { padding: 4px 9px; border: 1px solid var(--border); border-radius: 999px; color: var(--muted); font-size: 11px; }
+  .badge.accent { border-color: color-mix(in srgb, var(--accent) 35%, transparent); background: var(--accent-soft); color: var(--accent); }
+
+  section { padding: 46px 0 8px; }
+  h2 { margin: 0 0 9px; font-size: 28px; letter-spacing: -.025em; }
+  h3 { margin: 28px 0 8px; font-size: 17px; }
+  p { margin: 8px 0 14px; color: var(--muted); }
+  ul, ol { margin: 10px 0 18px; padding-left: 1.45rem; color: var(--muted); }
+  li { margin: 5px 0; padding-left: .2rem; }
+  strong { color: var(--text); }
+
+  .callout {
+    margin: 20px 0;
+    padding: 15px 17px;
+    border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+    border-left: 3px solid var(--accent);
+    border-radius: 8px;
+    background: var(--accent-soft);
+    color: var(--muted);
+  }
+  .callout strong { color: var(--accent); }
+  .callout.danger { border-color: color-mix(in srgb, var(--red) 32%, var(--border)); border-left-color: var(--red); background: color-mix(in srgb, var(--red) 8%, transparent); }
+  .callout.danger strong { color: var(--red); }
+
+  .steps { display: grid; gap: 11px; margin: 19px 0; counter-reset: steps; }
+  .step {
+    position: relative;
+    min-height: 67px;
+    padding: 14px 16px 14px 57px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+  }
+  .step::before {
+    counter-increment: steps;
+    content: counter(steps, decimal-leading-zero);
+    position: absolute;
+    left: 16px;
+    top: 15px;
+    color: var(--accent);
+    font: 700 12px/1 Consolas, monospace;
+  }
+  .step strong { display: block; margin-bottom: 2px; }
+  .step p { margin: 0; font-size: 13px; }
+
+  .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin: 18px 0; }
+  .card { padding: 17px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }
+  .card h3 { margin: 0 0 7px; }
+  .card p:last-child, .card ul:last-child { margin-bottom: 0; }
+  .card .label { color: var(--accent); font: 700 10px/1 Consolas, monospace; letter-spacing: .12em; }
+
+  .table-wrap { margin: 18px 0; border: 1px solid var(--border); border-radius: 10px; overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; background: var(--surface); font-size: 13px; }
+  th, td { padding: 11px 13px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+  th { color: var(--faint); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; }
+  td { color: var(--muted); }
+  tr:last-child td { border-bottom: 0; }
+
+  .metric-list { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 9px; margin: 18px 0; }
+  .metric { padding: 12px 14px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); }
+  .metric strong { display: block; font-size: 13px; }
+  .metric span { color: var(--faint); font-size: 12px; }
+  .footer { margin-top: 62px; padding-top: 24px; border-top: 1px solid var(--border); color: var(--faint); font-size: 12px; }
+
+  @media (max-width: 820px) {
+    .shell { display: block; }
+    .sidebar { position: sticky; z-index: 10; width: 100%; height: auto; padding: 10px 14px; border-right: 0; border-bottom: 1px solid var(--border); }
+    .brand { display: none; }
+    .nav-title, .theme-button { display: none; }
+    nav { display: flex; gap: 3px; overflow-x: auto; scrollbar-width: none; }
+    .nav-link { flex: 0 0 auto; white-space: nowrap; }
+    .nav-link::before { display: none; }
+    main { padding: 38px 22px 70px; }
+    .hero { padding-bottom: 36px; }
+    .grid, .metric-list { grid-template-columns: 1fr; }
+    section { padding-top: 36px; }
+  }
+
+  @media print {
+    .sidebar { display: none; }
+    .shell { display: block; }
+    main { width: 100%; padding: 0; }
+    body { background: #fff; color: #111; }
+    section { break-inside: avoid; }
   }
 </style>
 </head>
 <body>
+<div class="shell">
+  <aside class="sidebar">
+    <div class="brand">
+      <div class="brand-mark">D2</div>
+      <div><strong>D2RHub</strong><span>USER MANUAL · v0.8</span></div>
+    </div>
+    <nav id="nav">
+      <div class="nav-title">开始</div>
+      <a class="nav-link active" href="#overview">版本与功能</a>
+      <a class="nav-link" href="#quick-start">快速开始</a>
+      <a class="nav-link" href="#connections">路径配置</a>
+      <div class="nav-title">日常使用</div>
+      <a class="nav-link" href="#accounts">账号与认证</a>
+      <a class="nav-link" href="#launch">启动与多开</a>
+      <a class="nav-link" href="#settings">设置中心</a>
+      <a class="nav-link" href="#overlay">性能悬浮窗</a>
+      <a class="nav-link" href="#ocr">OCR 自动化</a>
+      <a class="nav-link" href="#stats">统计分析</a>
+      <a class="nav-link" href="#pet">Bongo Cat</a>
+      <div class="nav-title">维护</div>
+      <a class="nav-link" href="#data">数据与隐私</a>
+      <a class="nav-link" href="#troubleshooting">疑难解答</a>
+    </nav>
+    <button class="theme-button" id="themeToggle" type="button">切换明暗主题</button>
+  </aside>
 
-<aside class="sidebar">
-  <div class="sidebar-header">
-    D2RHub
-    <button class="theme-toggle" id="themeToggle">主题</button>
-  </div>
-  <nav class="nav-menu" id="navMenu">
-    <a href="#quick-start" class="nav-item active">快速入门</a>
-    <a href="#paths-config" class="nav-item">路径与配置</a>
-    <a href="#account-token" class="nav-item">账号与令牌</a>
-    <a href="#launch-controls" class="nav-item">启动控制</a>
-    <a href="#ocr-stats" class="nav-item">OCR与统计</a>
-    <a href="#overlay-pet" class="nav-item">悬浮窗与宠物</a>
-    <a href="#troubleshooting" class="nav-item">维护与疑难解答</a>
-    <a href="#data-locations" class="nav-item">数据存储位置</a>
-    <a href="#feedback" class="nav-item">反馈与支持</a>
-  </nav>
-</aside>
+  <main>
+    <header class="hero" id="overview">
+      <p class="eyebrow">CURRENT MANUAL · 2026-08</p>
+      <h1>D2RHub v0.8<br>使用手册</h1>
+      <p class="lede">面向当前 0.8.x 版本的完整操作说明，覆盖国服/国际服双版本、多账号认证、悬浮窗、OCR 与新版掉落统计。</p>
+      <div class="meta-row">
+        <span class="badge accent">适用版本 v0.8.x</span>
+        <span class="badge">Windows 10 / 11</span>
+        <span class="badge">Full / Lite</span>
+        <span class="badge">本地数据</span>
+      </div>
+    </header>
 
-<main class="main-content" id="mainContent">
-  <section id="quick-start" class="section">
-    <h2>快速入门</h2>
-    <p>欢迎使用 D2RHub。这是一款专为暗黑破坏神 2 重制版设计的现代化多账号管理与启动工具。</p>
-    <ul>
-      <li>在“账号”页面添加您的战网账号。</li>
-      <li>在“设置”页面配置游戏路径与战网客户端路径。</li>
-      <li>点击账号卡片上的“启动”按钮，自动完成账号切换与游戏启动。</li>
-    </ul>
-  </section>
+    <section>
+      <h2>选择 Full 还是 Lite</h2>
+      <p>两个版本共享账号管理、双版本隔离、多开、画质设置、悬浮窗和桌宠。差异集中在 OCR 识别与掉落统计。</p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>能力</th><th>Full</th><th>Lite</th></tr></thead>
+          <tbody>
+            <tr><td>账号管理、网页 Token / 战网认证、多开</td><td>支持</td><td>支持</td></tr>
+            <tr><td>国服与国际服安装档案、账号独立画质</td><td>支持</td><td>支持</td></tr>
+            <tr><td>性能悬浮窗、快捷键、Bongo Cat</td><td>支持</td><td>支持</td></tr>
+            <tr><td>场景/符文 OCR、掉落截图与统计页</td><td>支持</td><td>不包含</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-  <section id="paths-config" class="section">
-    <h2>路径与配置</h2>
-    <p>为了使 D2RHub 正常工作，需要正确配置游戏与战网的路径。</p>
-    <h3>游戏路径</h3>
-    <p>指向 <code>D2R.exe</code> 所在的文件夹。D2RHub 会通过该路径直接启动游戏，绕过繁琐的战网客户端启动流程（如果已缓存 Token）。</p>
-    <h3>战网客户端路径</h3>
-    <p>指向 <code>Battle.net.exe</code> 所在的文件夹。这用于在令牌过期时自动拉起客户端进行登录更新。</p>
-  </section>
+    <section id="quick-start">
+      <p class="eyebrow">01 · FIRST RUN</p>
+      <h2>快速开始</h2>
+      <div class="steps">
+        <div class="step"><strong>下载并安装</strong><p>从项目 Releases 下载 Full 或 Lite 的 MSI / NSIS 安装包，完成安装后启动 D2RHub。</p></div>
+        <div class="step"><strong>至少配置一套游戏版本</strong><p>在首次向导中填写国服或国际服的“游戏目录 + 存档目录”。使用战网认证时，再填写该版本的 Battle.net.exe。</p></div>
+        <div class="step"><strong>创建账号</strong><p>点击“添加账号”，依次选择昵称、区服、语言和认证方式。网页 Token 按向导取得并粘贴；战网认证按提示完成登录与快照。</p></div>
+        <div class="step"><strong>启动</strong><p>在账号卡片启动单个账号，或使用“启动全部 / 多选启动”。启动进度和错误会显示在卡片及运行日志中。</p></div>
+        <div class="step"><strong>按需开启辅助功能</strong><p>在“设置中心”开启悬浮窗、桌宠；Full 版还可在“自动化”选择已初始化账号并启用 OCR。</p></div>
+      </div>
+      <div class="callout"><strong>路径检测边界：</strong>当前向导可自动探测国服/国际服存档目录、Agent、Roaming 配置和 Edge/Chrome；游戏安装目录及 Battle.net.exe 仍应由你确认或手动选择。</div>
+    </section>
 
-  <section id="account-token" class="section">
-    <h2>账号与令牌机制</h2>
-    <p>D2RHub 支持战网的离线 Token 机制，实现无感切换账号。</p>
-    <ul>
-      <li><strong>添加账号：</strong>输入一个显示名称，便于您识别。</li>
-      <li><strong>Token模式：</strong>基于设备本地的离线令牌启动游戏，理论上只要不更换设备就不会过期，无需战网客户端参与。</li>
-      <li><strong>Battle.net模式：</strong>通过战网客户端登录机制启动，Token有效期通常在30天左右。过期后需要再次通过战网客户端授权。</li>
-    </ul>
-  </section>
+    <section id="connections">
+      <p class="eyebrow">02 · CONNECTIONS</p>
+      <h2>路径与双版本配置</h2>
+      <p>“设置中心 → 连接”把本机环境分为两套互不混用的安装档案。</p>
+      <div class="grid">
+        <div class="card"><span class="label">CN PROFILE</span><h3>国服</h3><p>供国服账号使用。存档目录通常带有 <code>Diablo II Resurrected (CN)</code> 标识。</p></div>
+        <div class="card"><span class="label">GLOBAL PROFILE</span><h3>国际服</h3><p>亚服、 美服和欧服共用同一套国际服游戏、战网和存档路径。</p></div>
+      </div>
+      <h3>每套档案需要什么</h3>
+      <ul>
+        <li><strong>游戏安装目录：</strong>包含 <code>D2R.exe</code>，任何认证方式都需要。</li>
+        <li><strong>存档目录：</strong>包含或将包含 <code>Settings.json</code>，任何认证方式都需要。</li>
+        <li><strong>Battle.net.exe：</strong>仅战网客户端认证需要；全部账号都用网页 Token 时可以留空。</li>
+      </ul>
+      <p>如果存档目录暂时没有 <code>Settings.json</code>，账号创建、登录和多开仍可用，但画质编辑、账号独立游戏配置和系统配置快照不可用。先用对应版本正常进入一次游戏，通常会生成该文件。</p>
+      <h3>辅助路径</h3>
+      <p>Agent 目录和 <code>%APPDATA%\Battle.net</code> 用于战网运行环境切换；Edge / Chrome 用于网页 Token 的独立浏览器档案。浏览器不是游戏启动的必需项，但使用内置 Token 获取流程时应配置。</p>
+    </section>
 
-  <section id="launch-controls" class="section">
-    <h2>启动控制</h2>
-    <p>D2RHub 提供了细粒度的启动参数控制：</p>
-    <ul>
-      <li><strong>等待进程退出：</strong>如果当前已有其他账号运行，您可以选择等待它们退出后再启动，或直接强行结束它们。</li>
-      <li><strong>启动参数：</strong>支持自定义命令行参数，如 <code>-txt</code> 或 <code>-direct</code>，可以在全局设置或单个账号设置中配置。</li>
-      <li><strong>多开支持：</strong>D2RHub 已内置多开处理机制，无需借助其他第三方工具或额外软件即可实现多账号同时运行。</li>
-    </ul>
-  </section>
+    <section id="accounts">
+      <p class="eyebrow">03 · ACCOUNTS</p>
+      <h2>账号与认证</h2>
+      <p>添加账号向导顺序为：<strong>昵称 → 区服/语言/配音 → 认证模式 → 获取 Token → 粘贴 Token</strong>。选择战网认证后，流程会改为客户端登录、采集本地认证快照并清理临时状态。</p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>方式</th><th>网页 Token（推荐）</th><th>战网客户端认证</th></tr></thead>
+          <tbody>
+            <tr><td>所需路径</td><td>游戏 + 存档；获取时需 Edge/Chrome</td><td>游戏 + 存档 + 对应版本 Battle.net.exe</td></tr>
+            <tr><td>启动路径</td><td>使用本机 DPAPI 加密保存的 Token 直启</td><td>恢复账号的 Battle.net / UnifiedAuth 本地快照后启动</td></tr>
+            <tr><td>特点</td><td>启动快，不依赖战网客户端常驻</td><td>适合无法使用网页 Token 的账号，流程更长</td></tr>
+            <tr><td>失效处理</td><td>服务端判定失效时，在账号操作中更新 Token</td><td>界面按 30 天提示有效状态；过期或登录失败时重新初始化</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout"><strong>凭据安全：</strong>Token 经 Windows DPAPI 绑定当前 Windows 用户后落盘。它仍属于敏感凭据，不要复制到 Issue、聊天记录或截图中，也不要分享账号目录。</div>
+      <h3>账号卡片可以做什么</h3>
+      <ul>
+        <li>启动账号、只启动 Battle.net（战网认证账号）、更新 Token 或重新初始化。</li>
+        <li>修改昵称、区服/认证信息、Mod 启动参数与常用参数列表。</li>
+        <li>设置游戏窗口 X/Y 位置，切换系统配置或账号独立配置。</li>
+        <li>展开快速设置修改分辨率和帧率；拖动卡片可改变账号顺序，快捷键位置会随顺序对应。</li>
+      </ul>
+    </section>
 
-  <section id="ocr-stats" class="section">
-    <h2>OCR 与掉落统计</h2>
-    <p>D2RHub 内置了强大的屏幕 OCR 引擎，用于自动识别游戏内的掉落和场景信息。</p>
-    <ul>
-      <li>在“设置”中启用 OCR 功能，并选择要监控的目标账号窗口。</li>
-      <li>OCR 将会在后台静默运行，识别到的符文和物品会自动记录。</li>
-      <li>点击主界面的“统计”按钮，可以查看详细的掉落历史和效率分析。</li>
-    </ul>
-  </section>
+    <section id="launch">
+      <p class="eyebrow">04 · LAUNCH</p>
+      <h2>启动、多选与进程控制</h2>
+      <ul>
+        <li><strong>单账号：</strong>点击账号卡片的启动按钮。</li>
+        <li><strong>启动全部：</strong>按当前账号顺序依次处理全部可启动账号。</li>
+        <li><strong>多选启动：</strong>进入多选模式，勾选目标账号后启动；适合只开固定组合。</li>
+        <li><strong>取消：</strong>启动队列运行时可以取消；程序会尽量收束本轮产生的战网/认证临时状态。</li>
+        <li><strong>窗口聚焦：</strong>使用已绑定快捷键，或在展开悬浮窗双击账号名称。</li>
+      </ul>
+      <div class="callout danger"><strong>“一键关闭”是强制操作：</strong>它会结束当前系统内所有 <code>D2R.exe</code> 进程，可能造成未保存的游戏进度丢失。确认所有游戏都可以退出后再执行。</div>
+      <p>多开通过 Windows 进程与句柄管理完成，不修改游戏文件、不写入游戏内存，也不注入 DLL；但第三方工具仍可能受到游戏条款、反作弊策略、系统权限或安全软件影响，请自行评估风险。</p>
+    </section>
 
-  <section id="overlay-pet" class="section">
-    <h2>悬浮窗与宠物 (Bongo Cat)</h2>
-    <p>增添游戏乐趣的小部件：</p>
-    <ul>
-      <li><strong>屏幕悬浮窗：</strong>可以在游戏上方显示当前的 OCR 状态、掉落总览等实时信息。</li>
-      <li><strong>Bongo Cat：</strong>一个可爱的敲击键盘小猫动画，它会根据您的鼠标和键盘操作实时反馈。在“设置”中可以调整其缩放比例和位置。</li>
-    </ul>
-  </section>
+    <section id="settings">
+      <p class="eyebrow">05 · SETTINGS CENTER</p>
+      <h2>设置中心速查</h2>
+      <div class="metric-list">
+        <div class="metric"><strong>连接</strong><span>国服/国际服游戏、战网、存档、Agent、Roaming 与浏览器路径</span></div>
+        <div class="metric"><strong>账号</strong><span>昵称、启动方式、Mod、窗口位置、分辨率、帧率与完整游戏设置</span></div>
+        <div class="metric"><strong>启动策略</strong><span>Agent 延时杀、进程数阈值或不处理；隔离浏览器和每日更新</span></div>
+        <div class="metric"><strong>快捷键</strong><span>按账号当前位置绑定全局聚焦组合键</span></div>
+        <div class="metric"><strong>显示</strong><span>界面语言、主题、主窗口/悬浮窗透明度、字体和悬浮窗开关</span></div>
+        <div class="metric"><strong>自动化（Full）</strong><span>OCR 目标账号、轮询频率、调试输出、重启与统计页</span></div>
+        <div class="metric"><strong>伴随</strong><span>Bongo Cat 开关、对话框、缩放和已解锁皮肤</span></div>
+        <div class="metric"><strong>维护</strong><span>打开日志目录、重新运行首次配置向导</span></div>
+      </div>
+      <h3>账号独立游戏设置</h3>
+      <p>选中已初始化账号后，可编辑启动、显示、图形、音频、玩法和地图设置。修改会自动保存。选择“系统配置”时跟随当前存档目录的 <code>Settings.json</code>；选择独立配置后，该账号保留自己的快照。需要以当前系统设置为基准时，使用“快照系统配置到当前账号”。</p>
+    </section>
 
-  <section id="troubleshooting" class="section">
-    <h2>维护与疑难解答</h2>
-    <ul>
-      <li><strong>自动更新：</strong>应用内不会直接替换可执行文件。检测到新版本后会打开 Release 安装包下载链接，请下载完整 MSI/NSIS 安装包后手动安装。</li>
-      <li><strong>战网无法启动：</strong>检查“设置 - 路径”中的 Battle.net.exe 路径是否存在，并确认 D2RHub 以管理员权限运行。</li>
-      <li><strong>账号初始化超时：</strong>确认战网已完成登录。若登录窗口未置顶，可手动切回 Battle.net 后继续等待。</li>
-      <li><strong>OCR 未识别：</strong>确认目标账号窗口标题与设置一致。需要排查时可临时开启 OCR 调试输出，排查完成后建议关闭。</li>
-      <li><strong>统计页无数据：</strong>统计数据来自本地数据库，只有启用 OCR 并识别到场景切换后才会产生记录。</li>
-      <li><strong>重置状态：</strong>退出 D2RHub 后备份并删除本地数据目录，再重新启动即可重新配置。</li>
-    </ul>
-  </section>
+    <section id="overlay">
+      <p class="eyebrow">06 · PERFORMANCE OVERLAY</p>
+      <h2>性能悬浮窗</h2>
+      <p>悬浮窗常驻桌面上方，可显示运行账号状态；Full 版开启 OCR 后还会显示当前场景计时、历史均值、符文掉落和邪恶区域信息。</p>
+      <h3>展开与迷你</h3>
+      <ul>
+        <li>展开模式双击空白区域，或迷你模式双击悬浮窗，可切换模式。</li>
+        <li>窗口获得焦点时按 <kbd>Enter</kbd> 或 <kbd>Space</kbd> 也可切换。</li>
+        <li>展开和迷你模式分别记住尺寸；展开模式双击账号可聚焦对应游戏。</li>
+        <li>迷你双层布局最低为 <strong>36 逻辑像素</strong>；继续向下缩放会切成单行，最低为 <strong>18 逻辑像素</strong>。拉高到阈值会恢复双层；高 DPI / 2K 屏会按系统缩放正确换算。</li>
+      </ul>
+      <h3>贴边吸附与自动隐藏</h3>
+      <ol>
+        <li>把展开或迷你悬浮窗拖到屏幕任一边缘并松开。</li>
+        <li>窗口会吸附到最近边缘并平滑推入屏幕外，只保留一条约 8px 的触发边。</li>
+        <li>把鼠标移到触发边，窗口会平滑抽出；鼠标离开后再次推入隐藏。</li>
+        <li>窗口抽出时向屏幕内部拖走，即可取消吸附。</li>
+      </ol>
+      <p>吸附位置按当前显示器的可用工作区计算，也适用于副屏和任务栏占用区域。系统启用“减少动态效果”时，抽出/隐藏会改为即时完成。</p>
+    </section>
 
-  <section id="data-locations" class="section">
-    <h2>数据存储与隐私</h2>
-    <p>D2RHub 的运行数据保存在本机，不会主动上传到远程服务器。常见数据包括：</p>
-    <ul>
-      <li><strong>全局配置：</strong>战网路径、游戏路径、存档路径、界面偏好和快捷键设置。</li>
-      <li><strong>账号数据：</strong>账号昵称、启动参数、窗口位置、DPAPI 加密后的 Token 数据和 Battle.net 认证快照。</li>
-      <li><strong>注册表备份：</strong>用于账号切换的 Battle.net UnifiedAuth 快照，仅保存在本机账号目录。</li>
-      <li><strong>OCR 数据：</strong>启用调试输出时，会在本机保存裁剪截图和识别日志用于排错。</li>
-      <li><strong>日志与统计：</strong>本地日志、刷图记录和统计数据库。</li>
-      <li><strong>本地统计 API：</strong>统计页面只读取本机数据，不对公网开放。</li>
-    </ul>
-    <p>如需迁移或备份，请复制 D2RHub 的应用数据目录。若要清理隐私数据，请先退出程序，再删除账号目录、日志、OCR 调试截图和统计数据库。</p>
-  </section>
+    <section id="ocr">
+      <p class="eyebrow">07 · OCR · FULL ONLY</p>
+      <h2>OCR 场景与符文识别</h2>
+      <p>Full 版在“设置中心 → 自动化”提供 OCR。开始前必须先选择一个<strong>已初始化</strong>账号作为固定目标窗口，否则开关不可用。</p>
+      <ul>
+        <li><strong>通道 A：</strong>识别场景名称与城镇状态，用于自动开始、切换和结束场景计时。</li>
+        <li><strong>通道 B：</strong>识别 1–33 号符文；同一场景内的每次识别以独立掉落条目保存。</li>
+        <li><strong>高级符文：</strong>#24 及以上会额外保存完整游戏窗口截图，并在统计页提供画廊。</li>
+        <li><strong>轮询频率：</strong>200–2000ms；间隔越短响应越快，也越消耗 CPU，默认 500ms。</li>
+      </ul>
+      <div class="callout"><strong>调试输出会占用磁盘：</strong>开启后会把处理图和 <code>ocr_debug.txt</code> 写到程序同级 <code>config\test</code>。仅在排查识别失败时开启，问题解决后关闭并按需清理。</div>
+      <p>场景记录在离开当前战斗场景、切换到另一场景或回城时写入数据库。尚未结束的当前场景不会提前计入历史统计。</p>
+    </section>
 
-  <section id="feedback" class="section">
-    <h2>反馈与支持</h2>
-    <p>如果您在使用过程中遇到 Bug 或有新功能建议，请访问我们的开源仓库提交 Issue。</p>
-    <p>感谢您的支持！</p>
-  </section>
-</main>
+    <section id="stats">
+      <p class="eyebrow">08 · LOCAL ANALYTICS</p>
+      <h2>新版统计页与统计口径</h2>
+      <p>从主界面顶部的统计按钮，或“设置中心 → 自动化 → 打开掉落统计图表”进入。页面读取本地数据库，并通过仅监听本机回环地址的临时 API 完成刷新、重命名和删除。</p>
+      <h3>统一筛选</h3>
+      <p>时间范围、角色、场景、掉落状态和具体符文会同时作用于顶部指标、趋势、对比、热力图、符文视图、截图与明细。明细另有搜索、排序和每页 50 条分页。</p>
+      <div class="grid">
+        <div class="card"><h3>效率与趋势</h3><p>总场次、总追踪时间、平均/中位/P90/最佳用时、按日趋势、场景效率和角色对比。</p></div>
+        <div class="card"><h3>掉落与时段</h3><p>掉落总数、每百场掉落、高级符文、命中率、平均间隔、星期×小时热力图。</p></div>
+        <div class="card"><h3>33 号符文图谱</h3><p>符文层级、1–33 号密度矩阵和排行榜；点击单个符文可直接加入筛选。</p></div>
+        <div class="card"><h3>管理与导出</h3><p>高级符文截图画廊、单条/整场删除、场景批量改名，以及筛选后的 CSV / JSON 导出。</p></div>
+      </div>
+      <h3>关键指标怎么计算</h3>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>指标</th><th>口径</th></tr></thead>
+          <tbody>
+            <tr><td>一场 / 场次</td><td>数据库中的一条已完成 <code>scene_record</code>；不是一次游戏启动，也不是一次掉落。</td></tr>
+            <tr><td>平均 / 中位 / P90 / 最佳</td><td>筛选后各场 <code>timer_seconds</code> 的算术平均、50 分位、90 分位和最小值。</td></tr>
+            <tr><td>掉落数</td><td>筛选后所有记录的 <code>drops</code> 数组元素总和；同场多个符文分别计数。</td></tr>
+            <tr><td>每百场掉落</td><td><code>掉落数 ÷ 场次 × 100</code>，方便不同场景样本量对比。</td></tr>
+            <tr><td>有掉落场 / 命中率</td><td>至少一条掉落的场数 ÷ 场次；高级符文命中率则只看 #24–#33。</td></tr>
+            <tr><td>高级符文间隔</td><td>按时间排序后，相邻“含高级符文的场”之间跨过的场次数平均值；样本不足时不显示。</td></tr>
+            <tr><td>截图数</td><td>存在 <code>screenshot_path</code> 的掉落条目数量，不等同于高级符文总数。</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout danger"><strong>删除不可撤销：</strong>在统计页删除整场或单个掉落会直接改写本地数据库。重要数据请先备份 <code>config\stateData</code> 或导出 JSON。</div>
+    </section>
+
+    <section id="pet">
+      <p class="eyebrow">09 · COMPANION</p>
+      <h2>Bongo Cat</h2>
+      <p>在“设置中心 → 伴随”开启桌宠。猫咪会响应键盘和鼠标输入，可显示随机对话及轻量系统状态提示。</p>
+      <ul>
+        <li>拖动猫咪本体可以改变屏幕位置；右键打开皮肤、计数重置和隐藏菜单。</li>
+        <li>设置中心可调整 0.5×–5.0× 缩放、气泡对话框和已解锁皮肤。</li>
+        <li>“法师猫咪”属于随机彩蛋解锁项；未解锁时不会出现在可选皮肤中。</li>
+      </ul>
+    </section>
+
+    <section id="data">
+      <p class="eyebrow">10 · DATA & PRIVACY</p>
+      <h2>数据位置、备份与更新</h2>
+      <p>D2RHub 当前使用<strong>程序可执行文件同级目录</strong>保存运行数据，而不是 Windows AppData：</p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>位置</th><th>内容</th></tr></thead>
+          <tbody>
+            <tr><td><code>config\global_config.json</code></td><td>全局路径、界面、启动策略、快捷键、OCR 与桌宠设置</td></tr>
+            <tr><td><code>config\accounts\</code></td><td>账号元数据、DPAPI 加密 Token、Battle.net / UnifiedAuth 快照、账号游戏设置</td></tr>
+            <tr><td><code>config\stateData\data.db</code></td><td>OCR 场景与符文掉落数据库</td></tr>
+            <tr><td><code>config\stateData\img\</code></td><td>#24 及以上符文截图</td></tr>
+            <tr><td><code>config\test\</code></td><td>启用 OCR 调试输出后产生的处理图与日志</td></tr>
+            <tr><td><code>logs\</code></td><td>程序运行日志；每次启动新建，自动最多保留 16 个</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>迁移或重装前，退出 D2RHub 并备份整个 <code>config</code> 目录；排障需要时也可一并备份 <code>logs</code>。不要在程序运行时手工编辑或覆盖数据库和账号快照。</p>
+      <p>程序不会在应用内替换正在运行的可执行文件。“每日检查更新”每天首次启动时检查新版本；发现更新后会打开项目 Release / 安装包页面，由你下载 MSI 或 NSIS 安装包完成升级。</p>
+      <p>D2RHub 不会主动上传账号配置或 Token。联网范围包括 Battle.net Token 登录页面、GitHub Releases 更新接口和邪恶区域信息接口；OCR 调试图片与统计数据留在本机。</p>
+    </section>
+
+    <section id="troubleshooting">
+      <p class="eyebrow">11 · TROUBLESHOOTING</p>
+      <h2>疑难解答</h2>
+      <h3>账号无法创建或对应区服不可选</h3>
+      <p>检查该版本的游戏目录和存档目录是否成组配置。战网认证还需对应版本 Battle.net.exe；亚/美/欧服统一检查国际服档案。</p>
+      <h3>战网初始化超时或快照失效</h3>
+      <p>确认 Battle.net 已实际登录完成、路径对应正确版本，并避免同时执行另一个战网认证操作。账号卡片显示过期或启动失败时，执行重新初始化。</p>
+      <h3>网页 Token 获取页打不开</h3>
+      <p>在“连接”中重新探测或手动选择 Edge / Chrome，关闭同类型浏览器后重试独立浏览器流程。也可以手动取得 Token 后回到向导粘贴。</p>
+      <h3>画质设置无法读取</h3>
+      <p>确认存档路径正确且包含 <code>Settings.json</code>。先用对应国服/国际服客户端正常进入游戏一次，再回到设置中心加载。</p>
+      <h3>悬浮窗吸附后找不到</h3>
+      <p>沿最近使用的屏幕边缘缓慢移动鼠标，触发边会让窗口抽出。仍无法找到时，在“显示”中关闭再开启悬浮窗，或重启应用。</p>
+      <h3>迷你窗无法变成单行</h3>
+      <p>继续从底边向上压缩；到 36 逻辑像素附近会切换为单行，并可降至 18。Windows 缩放比例会影响物理像素，不影响逻辑阈值。</p>
+      <h3>OCR 无数据或识别不稳定</h3>
+      <p>确认目标账号已初始化、游戏窗口存在且昵称可匹配。先用默认 500ms；需要排查时临时开启调试输出并点击“应用配置并重启 OCR”。一条统计记录只在当前场景结束后写入。</p>
+      <h3>进一步排查</h3>
+      <p>从“维护 → 打开日志”查看最新日志。提交 Issue 前删除 Token、Windows 用户名、个人路径和含敏感画面的截图；安全问题请通过项目安全政策私下报告。</p>
+    </section>
+
+    <footer class="footer">
+      D2RHub v0.8.x · 非 Blizzard Entertainment 官方项目。Diablo、Diablo II: Resurrected 与 Battle.net 为其各自权利人的商标。
+    </footer>
+  </main>
+</div>
 
 <script>
-  // Theme Toggle
-  const themeToggle = document.getElementById('themeToggle');
-  const htmlEl = document.documentElement;
+  const root = document.documentElement;
+  const savedTheme = localStorage.getItem("d2rhub-guide-theme");
+  if (savedTheme === "light" || savedTheme === "dark") root.dataset.theme = savedTheme;
 
-  // Load saved theme
-  const savedTheme = localStorage.getItem('d2rhub-theme') || 'dark';
-  htmlEl.setAttribute('data-theme', savedTheme);
-
-  themeToggle.addEventListener('click', () => {
-    const currentTheme = htmlEl.getAttribute('data-theme');
-    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    htmlEl.setAttribute('data-theme', newTheme);
-    localStorage.setItem('d2rhub-theme', newTheme);
+  document.getElementById("themeToggle").addEventListener("click", () => {
+    const next = root.dataset.theme === "dark" ? "light" : "dark";
+    root.dataset.theme = next;
+    localStorage.setItem("d2rhub-guide-theme", next);
   });
 
-  // Intersection Observer for Active Nav
-  const sections = document.querySelectorAll('.section');
-  const navItems = document.querySelectorAll('.nav-item');
-
-  const observerOptions = {
-    root: document.getElementById('mainContent'),
-    rootMargin: '0px',
-    threshold: 0.5
-  };
-
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        const id = entry.target.getAttribute('id');
-        navItems.forEach(item => {
-          if (item.getAttribute('href') === `#${id}`) {
-            item.classList.add('active');
-          } else {
-            item.classList.remove('active');
-          }
-        });
-      }
-    });
-  }, observerOptions);
-
+  const links = [...document.querySelectorAll(".nav-link")];
+  const sections = links
+    .map(link => document.querySelector(link.getAttribute("href")))
+    .filter(Boolean);
+  const observer = new IntersectionObserver(entries => {
+    const visible = entries.filter(entry => entry.isIntersecting);
+    if (!visible.length) return;
+    const current = visible.sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0].target.id;
+    links.forEach(link => link.classList.toggle("active", link.getAttribute("href") === `#${current}`));
+  }, { rootMargin: "-12% 0px -70% 0px", threshold: [0, .2, .6] });
   sections.forEach(section => observer.observe(section));
 </script>
 </body>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,8 @@ mod state;
 mod stats;
 #[cfg(target_os = "windows")]
 mod token_registry_trace;
+#[cfg(any(feature = "ocr", test))]
+mod stats_page;
 mod tray;
 
 use crate::commands::global_config::GlobalConfig;

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 use tauri::Manager;
 
 use crate::state::SharedState;
+use crate::stats_page::{render_stats_template, stats_template_candidates};
 
 /// 单条符文掉落记录
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -584,35 +585,23 @@ pub fn open_stats_page(
         .path()
         .resource_dir()
         .map_err(|e| format!("获取资源目录失败: {}", e))?;
-    let mut template_path = resource_dir.join("docs").join("stats.html");
-
-    // NSIS 安装包回退：资源可能被包裹在 _up_ 子目录中
-    if !template_path.exists() {
-        let nsis_path = resource_dir.join("_up_").join("docs").join("stats.html");
-        if nsis_path.exists() {
-            template_path = nsis_path;
-        }
-    }
-
-    // 开发模式回退：从项目根目录 docs/ 查找
-    if !template_path.exists() {
-        let dev_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap_or(std::path::Path::new("."))
-            .join("docs")
-            .join("stats.html");
-        if dev_path.exists() {
-            template_path = dev_path;
-        }
-    }
-
-    if !template_path.exists() {
-        return Err(format!(
-            "stats.html 模板不存在: {} (资源目录: {})",
-            template_path.display(),
-            resource_dir.display()
-        ));
-    }
+    let dev_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .join("docs")
+        .join("stats.html");
+    // 调试运行时工作区模板是事实来源，避免 target/debug/_up_ 中的旧打包副本遮蔽最新页面。
+    // 发布版本仍然优先使用安装包资源，项目目录只作为最后回退。
+    let template_path = stats_template_candidates(&resource_dir, &dev_path, cfg!(debug_assertions))
+        .into_iter()
+        .find(|path| path.exists())
+        .ok_or_else(|| {
+            format!(
+                "stats.html 模板不存在 (资源目录: {}, 开发路径: {})",
+                resource_dir.display(),
+                dev_path.display()
+            )
+        })?;
 
     let template = std::fs::read_to_string(&template_path).map_err(|e| {
         format!(
@@ -625,9 +614,14 @@ pub fn open_stats_page(
     // 3. 启动统计 API 服务并注入端口号
     let api_port = start_stats_api(state.app_data_dir.clone())?;
     let stats_json = escape_json_for_html_script(&stats_json);
-    let html = template
-        .replace("{{STATS_DATA}}", &stats_json)
-        .replace("{{STATS_API_PORT}}", &api_port.to_string());
+    let stats_theme = state
+        .config
+        .read()
+        .as_ref()
+        .map(|config| config.theme.as_str())
+        .unwrap_or("light")
+        .to_string();
+    let html = render_stats_template(&template, &stats_json, api_port, &stats_theme);
 
     // 4. 写入 stateData/stats.html（使相对路径 img/ 可用）
     let state_data_dir = Path::new(&state.app_data_dir).join("stateData");

--- a/src-tauri/src/stats_page.rs
+++ b/src-tauri/src/stats_page.rs
@@ -1,0 +1,73 @@
+use std::path::{Path, PathBuf};
+
+fn normalize_stats_theme(theme: &str) -> &'static str {
+    if theme == "light" {
+        "light"
+    } else {
+        "onyx"
+    }
+}
+
+pub(crate) fn stats_template_candidates(
+    resource_dir: &Path,
+    dev_path: &Path,
+    prefer_dev: bool,
+) -> Vec<PathBuf> {
+    let resource_path = resource_dir.join("docs").join("stats.html");
+    let nsis_path = resource_dir.join("_up_").join("docs").join("stats.html");
+
+    if prefer_dev {
+        vec![dev_path.to_path_buf(), resource_path, nsis_path]
+    } else {
+        vec![resource_path, nsis_path, dev_path.to_path_buf()]
+    }
+}
+
+pub(crate) fn render_stats_template(
+    template: &str,
+    stats_json: &str,
+    api_port: u16,
+    theme: &str,
+) -> String {
+    template
+        .replace("{{STATS_DATA}}", stats_json)
+        .replace("{{STATS_API_PORT}}", &api_port.to_string())
+        .replace("{{STATS_THEME}}", normalize_stats_theme(theme))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn light_app_theme_is_injected_without_a_stale_local_override() {
+        let template = include_str!("../../docs/stats.html");
+        let rendered = render_stats_template(template, "[]", 43123, "light");
+
+        assert!(rendered.contains("<html lang=\"zh-CN\" data-theme=\"light\">"));
+        assert!(rendered.contains("const API_PORT=43123"));
+        assert!(!rendered.contains("{{STATS_API_PORT}}"));
+        assert!(!rendered.contains("{{STATS_THEME}}"));
+        assert!(!rendered.contains("d2rhub-stats-theme"));
+    }
+
+    #[test]
+    fn unknown_app_theme_falls_back_to_onyx() {
+        assert_eq!(normalize_stats_theme("onyx"), "onyx");
+        assert_eq!(normalize_stats_theme("unexpected"), "onyx");
+    }
+
+    #[test]
+    fn debug_template_candidates_prefer_the_workspace_source() {
+        let resource_dir = Path::new("target/debug");
+        let dev_path = Path::new("docs/stats.html");
+        let candidates = stats_template_candidates(resource_dir, dev_path, true);
+
+        assert_eq!(candidates[0], dev_path);
+        assert_eq!(candidates[1], resource_dir.join("docs").join("stats.html"));
+        assert_eq!(
+            candidates[2],
+            resource_dir.join("_up_").join("docs").join("stats.html")
+        );
+    }
+}

--- a/src/pages/Overlay.tsx
+++ b/src/pages/Overlay.tsx
@@ -8,10 +8,10 @@ import { invoke } from "@tauri-apps/api/core";
 import {
   currentMonitor,
   getCurrentWindow,
+  PhysicalPosition,
   LogicalPosition,
   LogicalSize,
 } from "@tauri-apps/api/window";
-import { useWindowGeometrySave } from "../hooks/useWindowGeometrySave";
 import { surfaceOpacityVars } from "../styles/surfaceOpacity";
 import { isEnglishLanguage } from "../i18n";
 import { translateTerrorZoneAreaName } from "../data/terrorZoneAreaNames";
@@ -20,11 +20,26 @@ import {
   initialMiniOverlayLayout,
   MINI_OVERLAY_MIN_HEIGHT,
   MINI_OVERLAY_MIN_WIDTH,
+  miniOverlayMinHeightForLayout,
   normalizeMiniOverlaySize,
   resolveMiniOverlayLayoutAfterResize,
   type MiniOverlayLayout,
   type OverlaySize,
 } from "../utils/overlaySizing";
+import {
+  calculateOverlayDockAnimationDuration,
+  calculateOverlayDockPlacement,
+  easeOverlayDockProgress,
+  findOverlayDockEdge,
+  OVERLAY_DOCK_REVEAL_SIZE,
+  OVERLAY_DOCK_SNAP_DISTANCE,
+  pointDistance,
+  type OverlayDockEdge,
+  type OverlayDockPlacement,
+  type PhysicalPoint,
+  type PhysicalRect,
+  type PhysicalSize,
+} from "../utils/overlayDocking";
 
 interface OcrTextItem {
   text: string;
@@ -70,6 +85,16 @@ const EXPANDED_OVERLAY_MIN_WIDTH = 200;
 const EXPANDED_OVERLAY_MIN_HEIGHT = 180;
 const DEFAULT_EXPANDED_OVERLAY_SIZE: OverlaySize = { width: 280, height: 340 };
 const OVERLAY_WINDOW_DRAG_THRESHOLD_PX = 4;
+const OVERLAY_DOCK_SETTLE_DELAY_MS = 260;
+const OVERLAY_DOCK_HIDE_DELAY_MS = 420;
+
+type OverlayDockPhase = "shown" | "hidden" | "moving";
+
+interface OverlayDockState {
+  placement: OverlayDockPlacement;
+  workArea: PhysicalRect;
+  phase: OverlayDockPhase;
+}
 
 function readStoredOverlayMode(): OverlayDisplayMode {
   try {
@@ -154,6 +179,7 @@ async function resolveDefaultMiniOverlaySize(): Promise<OverlaySize> {
 async function applyMiniOverlaySize(
   win: ReturnType<typeof getCurrentWindow>,
   miniSize: OverlaySize,
+  miniLayout: MiniOverlayLayout,
 ) {
   const logicalSize = new LogicalSize(miniSize.width, miniSize.height);
 
@@ -162,7 +188,10 @@ async function applyMiniOverlaySize(
   await win.setMaxSize(null);
   await win.setSize(logicalSize);
   await win.setMinSize(
-    new LogicalSize(MINI_OVERLAY_MIN_WIDTH, MINI_OVERLAY_MIN_HEIGHT),
+    new LogicalSize(
+      MINI_OVERLAY_MIN_WIDTH,
+      miniOverlayMinHeightForLayout(miniLayout),
+    ),
   );
 }
 
@@ -301,6 +330,7 @@ export function Overlay() {
       readStoredMiniOverlayLayout() ?? "single",
     ),
   );
+  const miniLayoutRef = useRef(miniLayout);
   const miniHeightRef = useRef<number | null>(miniSizeRef.current?.height ?? null);
   const expandedSizeRef = useRef<OverlaySize>(
     readStoredExpandedOverlaySize() ?? DEFAULT_EXPANDED_OVERLAY_SIZE,
@@ -322,6 +352,14 @@ export function Overlay() {
   } | null>(null);
   const suppressOverlayDoubleClickUntilRef = useRef(0);
   const [accountStripScrollable, setAccountStripScrollable] = useState(false);
+  const dockStateRef = useRef<OverlayDockState | null>(null);
+  const dockMoveTimerRef = useRef<number | null>(null);
+  const dockHideTimerRef = useRef<number | null>(null);
+  const dockAnimationTokenRef = useRef(0);
+  const programmaticDockMoveRef = useRef(false);
+  const pointerInsideDockRef = useRef(false);
+  const [dockEdge, setDockEdge] = useState<OverlayDockEdge | null>(null);
+  const [dockPhase, setDockPhase] = useState<OverlayDockPhase | null>(null);
 
   const isPollerActive = !!(config?.enable_overlay || config?.ocr_enabled);
 
@@ -343,28 +381,307 @@ export function Overlay() {
     };
   }
 
+  function clearDockMoveTimer() {
+    if (dockMoveTimerRef.current !== null) {
+      window.clearTimeout(dockMoveTimerRef.current);
+      dockMoveTimerRef.current = null;
+    }
+  }
+
+  function clearDockHideTimer() {
+    if (dockHideTimerRef.current !== null) {
+      window.clearTimeout(dockHideTimerRef.current);
+      dockHideTimerRef.current = null;
+    }
+  }
+
+  function updateDockState(state: OverlayDockState | null) {
+    dockStateRef.current = state;
+    setDockEdge(state?.placement.edge ?? null);
+    setDockPhase(state?.phase ?? null);
+  }
+
+  function cancelDockAnimation() {
+    dockAnimationTokenRef.current += 1;
+    programmaticDockMoveRef.current = false;
+  }
+
+  function clearDocking() {
+    clearDockMoveTimer();
+    clearDockHideTimer();
+    cancelDockAnimation();
+    updateDockState(null);
+  }
+
+  async function persistOverlayGeometry(positionOverride?: PhysicalPoint) {
+    try {
+      const win = getCurrentWindow();
+      const [position, size, scale] = await Promise.all([
+        positionOverride ? Promise.resolve(positionOverride) : win.outerPosition(),
+        win.outerSize(),
+        win.scaleFactor(),
+      ]);
+      await invoke("save_overlay_geometry", {
+        geometry: {
+          x: Math.round(position.x / scale),
+          y: Math.round(position.y / scale),
+          width: Math.round(size.width / scale),
+          height: Math.round(size.height / scale),
+        },
+      });
+    } catch (err) {
+      console.warn("[Overlay] persist geometry failed:", err);
+    }
+  }
+
+  async function animateOverlayPosition(target: PhysicalPoint, finalPhase: OverlayDockPhase) {
+    const state = dockStateRef.current;
+    if (!state) return;
+
+    const win = getCurrentWindow();
+    const start = await win.outerPosition();
+    if (pointDistance(start, target) < 1) {
+      const settled = { ...state, phase: finalPhase };
+      updateDockState(settled);
+      return;
+    }
+
+    const token = dockAnimationTokenRef.current + 1;
+    dockAnimationTokenRef.current = token;
+    programmaticDockMoveRef.current = true;
+    updateDockState({ ...state, phase: "moving" });
+
+    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (reduceMotion) {
+      try {
+        await win.setPosition(new PhysicalPosition(target.x, target.y));
+      } catch (err) {
+        console.warn("[Overlay] reduced-motion dock move failed:", err);
+        programmaticDockMoveRef.current = false;
+        return;
+      }
+    } else {
+      const motion = finalPhase === "hidden" ? "hide" : "reveal";
+      const duration = calculateOverlayDockAnimationDuration(pointDistance(start, target), motion);
+      let animationFailed = false;
+
+      await new Promise<void>((resolve) => {
+        let startedAt: number | null = null;
+        let pendingPosition: PhysicalPoint | null = null;
+        let moveInFlight = false;
+        let animationFinished = false;
+        let resolved = false;
+        let lastRequestedPosition: PhysicalPoint | null = null;
+
+        const finish = () => {
+          if (resolved) return;
+          resolved = true;
+          resolve();
+        };
+
+        const flushLatestPosition = () => {
+          if (resolved || moveInFlight || !pendingPosition) return;
+          const nextPosition = pendingPosition;
+          pendingPosition = null;
+          moveInFlight = true;
+
+          void win.setPosition(new PhysicalPosition(nextPosition.x, nextPosition.y)).then(() => {
+            moveInFlight = false;
+            if (dockAnimationTokenRef.current !== token) {
+              pendingPosition = null;
+              finish();
+              return;
+            }
+            flushLatestPosition();
+            if (animationFinished && !moveInFlight && !pendingPosition) finish();
+          }).catch((err) => {
+            animationFailed = true;
+            moveInFlight = false;
+            pendingPosition = null;
+            console.warn("[Overlay] dock animation move failed:", err);
+            finish();
+          });
+        };
+
+        const queueLatestPosition = (position: PhysicalPoint) => {
+          if (
+            lastRequestedPosition
+            && lastRequestedPosition.x === position.x
+            && lastRequestedPosition.y === position.y
+          ) {
+            return;
+          }
+          lastRequestedPosition = position;
+          pendingPosition = position;
+          flushLatestPosition();
+        };
+
+        const step = (now: number) => {
+          if (resolved) return;
+          if (dockAnimationTokenRef.current !== token) {
+            pendingPosition = null;
+            if (!moveInFlight) finish();
+            return;
+          }
+          if (startedAt === null) startedAt = now;
+          const progress = Math.min(1, (now - startedAt) / duration);
+          const eased = easeOverlayDockProgress(progress, motion);
+          queueLatestPosition({
+            x: Math.round(start.x + (target.x - start.x) * eased),
+            y: Math.round(start.y + (target.y - start.y) * eased),
+          });
+
+          if (progress >= 1) {
+            animationFinished = true;
+            queueLatestPosition({ x: target.x, y: target.y });
+            if (!moveInFlight && !pendingPosition) finish();
+          } else {
+            window.requestAnimationFrame(step);
+          }
+        };
+
+        window.requestAnimationFrame(step);
+      });
+
+      if (animationFailed) {
+        programmaticDockMoveRef.current = false;
+        return;
+      }
+    }
+
+    if (dockAnimationTokenRef.current !== token) return;
+    const latest = dockStateRef.current;
+    if (latest) updateDockState({ ...latest, phase: finalPhase });
+    window.setTimeout(() => {
+      if (dockAnimationTokenRef.current === token) {
+        programmaticDockMoveRef.current = false;
+      }
+    }, 32);
+  }
+
+  function scheduleDockHide(delay = OVERLAY_DOCK_HIDE_DELAY_MS) {
+    clearDockHideTimer();
+    dockHideTimerRef.current = window.setTimeout(() => {
+      dockHideTimerRef.current = null;
+      const state = dockStateRef.current;
+      if (!state || pointerInsideDockRef.current) return;
+      void animateOverlayPosition(state.placement.hidden, "hidden");
+    }, delay);
+  }
+
+  async function revealDockedOverlay() {
+    clearDockHideTimer();
+    const state = dockStateRef.current;
+    if (!state || state.phase === "shown") return;
+    await animateOverlayPosition(state.placement.visible, "shown");
+  }
+
+  async function evaluateOverlayDocking() {
+    if (programmaticDockMoveRef.current || modeTransitionRef.current) return;
+    try {
+      const win = getCurrentWindow();
+      const [position, size, monitor, scale] = await Promise.all([
+        win.outerPosition(),
+        win.outerSize(),
+        currentMonitor(),
+        win.scaleFactor(),
+      ]);
+      if (!monitor) {
+        await persistOverlayGeometry({ x: position.x, y: position.y });
+        return;
+      }
+      const workArea: PhysicalRect = {
+        x: monitor.workArea.position.x,
+        y: monitor.workArea.position.y,
+        width: monitor.workArea.size.width,
+        height: monitor.workArea.size.height,
+      };
+      const physicalSize: PhysicalSize = { width: size.width, height: size.height };
+      const edge = findOverlayDockEdge(
+        { x: position.x, y: position.y },
+        physicalSize,
+        workArea,
+        OVERLAY_DOCK_SNAP_DISTANCE * scale,
+      );
+      if (!edge) {
+        updateDockState(null);
+        await persistOverlayGeometry({ x: position.x, y: position.y });
+        return;
+      }
+
+      const placement = calculateOverlayDockPlacement(
+        edge,
+        { x: position.x, y: position.y },
+        physicalSize,
+        workArea,
+        OVERLAY_DOCK_REVEAL_SIZE * scale,
+      );
+      updateDockState({ placement, workArea, phase: "moving" });
+      await persistOverlayGeometry(placement.visible);
+      await animateOverlayPosition(placement.visible, "shown");
+      scheduleDockHide();
+    } catch (err) {
+      console.warn("[Overlay] evaluate edge docking failed:", err);
+    }
+  }
+
+  async function refreshDockPlacementAfterResize() {
+    const state = dockStateRef.current;
+    if (!state) return;
+    try {
+      const win = getCurrentWindow();
+      const [size, scale] = await Promise.all([win.outerSize(), win.scaleFactor()]);
+      const placement = calculateOverlayDockPlacement(
+        state.placement.edge,
+        state.placement.visible,
+        { width: size.width, height: size.height },
+        state.workArea,
+        OVERLAY_DOCK_REVEAL_SIZE * scale,
+      );
+      const next = { ...state, placement, phase: "shown" as const };
+      updateDockState(next);
+      await persistOverlayGeometry(placement.visible);
+      await animateOverlayPosition(placement.visible, "shown");
+    } catch (err) {
+      console.warn("[Overlay] refresh dock placement failed:", err);
+    }
+  }
+
   function restoreMiniLayoutForHeight(height: number) {
     const nextLayout = initialMiniOverlayLayout(
       height,
       readStoredMiniOverlayLayout() ?? "single",
     );
     miniHeightRef.current = height;
+    miniLayoutRef.current = nextLayout;
     setMiniLayout(nextLayout);
     storeMiniOverlayLayout(nextLayout);
+    return nextLayout;
   }
 
   function updateMiniLayoutForResize(height: number) {
     const previousHeight = miniHeightRef.current ?? height;
     miniHeightRef.current = height;
-    setMiniLayout((currentLayout) => {
-      const nextLayout = resolveMiniOverlayLayoutAfterResize(
-        currentLayout,
-        previousHeight,
-        height,
-      );
-      if (nextLayout !== currentLayout) storeMiniOverlayLayout(nextLayout);
-      return nextLayout;
-    });
+    const currentLayout = miniLayoutRef.current;
+    const nextLayout = resolveMiniOverlayLayoutAfterResize(
+      currentLayout,
+      previousHeight,
+      height,
+    );
+    if (nextLayout !== currentLayout) {
+      miniLayoutRef.current = nextLayout;
+      setMiniLayout(nextLayout);
+      storeMiniOverlayLayout(nextLayout);
+      void getCurrentWindow().setMinSize(
+        new LogicalSize(
+          MINI_OVERLAY_MIN_WIDTH,
+          miniOverlayMinHeightForLayout(nextLayout),
+        ),
+      ).catch((err) => {
+        console.warn("[Overlay] update mini minimum height failed:", err);
+      });
+    }
+    return nextLayout;
   }
 
   async function setWindowHeightOnce(targetHeight: number) {
@@ -457,6 +774,9 @@ export function Overlay() {
     setOverlayPanelHeight(null);
 
     try {
+      if (dockStateRef.current) {
+        await revealDockedOverlay();
+      }
       const { win, width, height } = await getOverlayWindowSize();
 
       if (displayModeRef.current === "expanded") {
@@ -475,11 +795,9 @@ export function Overlay() {
           readStoredMiniOverlaySize() ??
           await resolveDefaultMiniOverlaySize();
         miniSizeRef.current = miniSize;
-        if (miniHeightRef.current === null) {
-          restoreMiniLayoutForHeight(miniSize.height);
-        }
+        const restoredLayout = restoreMiniLayoutForHeight(miniSize.height);
         storeMiniOverlaySize(miniSize);
-        await applyMiniOverlaySize(win, miniSize);
+        await applyMiniOverlaySize(win, miniSize, restoredLayout);
       } else {
         const miniSize = normalizeMiniOverlaySize({ width, height });
         miniSizeRef.current = miniSize;
@@ -494,6 +812,9 @@ export function Overlay() {
         } catch {}
 
         await applyExpandedOverlaySize(win, expandedSize);
+      }
+      if (dockStateRef.current) {
+        await refreshDockPlacementAfterResize();
       }
     } catch (err) {
       console.warn("[Overlay] toggle information overlay mode failed:", err);
@@ -584,6 +905,7 @@ export function Overlay() {
     }
     event.preventDefault();
     event.stopPropagation();
+    clearDocking();
     void getCurrentWindow().startDragging().catch((err) => {
       console.warn("[Overlay] start window dragging failed:", err);
     });
@@ -891,16 +1213,19 @@ export function Overlay() {
         if (cancelled) return;
 
         miniSizeRef.current = miniSize;
-        restoreMiniLayoutForHeight(miniSize.height);
+        const restoredMiniLayout = restoreMiniLayoutForHeight(miniSize.height);
         expandedSizeRef.current = expandedSize;
         storeMiniOverlaySize(miniSize);
         storeExpandedOverlaySize(expandedSize);
 
         if (displayModeRef.current === "mini") {
-          await applyMiniOverlaySize(win, miniSize);
+          await applyMiniOverlaySize(win, miniSize, restoredMiniLayout);
         } else {
           await applyExpandedOverlaySize(win, expandedSize);
         }
+        window.setTimeout(() => {
+          if (!cancelled) void evaluateOverlayDocking();
+        }, OVERLAY_DOCK_SETTLE_DELAY_MS);
       } catch (err) {
         console.warn("[Overlay] restore information overlay geometry failed:", err);
       }
@@ -920,10 +1245,16 @@ export function Overlay() {
     (async () => {
       try {
         const win = getCurrentWindow();
-        const stopListening = await win.onResized(() => {
+        const stopListening = await win.onResized((event) => {
           const resizedMode = displayModeRef.current;
           if (resizedMode === "mini") {
-            updateMiniLayoutForResize(Math.max(MINI_OVERLAY_MIN_HEIGHT, window.innerHeight));
+            void win.scaleFactor().then((scale) => {
+              const logicalHeight = Math.max(
+                MINI_OVERLAY_MIN_HEIGHT,
+                event.payload.height / scale,
+              );
+              updateMiniLayoutForResize(logicalHeight);
+            });
           }
           if (overlaySizeSaveTimerRef.current !== null) {
             window.clearTimeout(overlaySizeSaveTimerRef.current);
@@ -941,6 +1272,11 @@ export function Overlay() {
                 const expandedSize = normalizeExpandedOverlaySize({ width, height });
                 expandedSizeRef.current = expandedSize;
                 storeExpandedOverlaySize(expandedSize);
+              }
+              if (dockStateRef.current) {
+                await refreshDockPlacementAfterResize();
+              } else {
+                await persistOverlayGeometry();
               }
             } catch (err) {
               console.warn(`[Overlay] persist ${resizedMode} size failed:`, err);
@@ -963,7 +1299,38 @@ export function Overlay() {
     };
   }, []);
 
-  useWindowGeometrySave("save_overlay_geometry", 1, 1);
+  // Native dragging leaves the webview pointer stream, so movement is observed
+  // at the window level and settled after the final OS move event.
+  useEffect(() => {
+    let cancelled = false;
+    let unlistenMove: (() => void) | undefined;
+
+    (async () => {
+      try {
+        const win = getCurrentWindow();
+        const stopListening = await win.onMoved(() => {
+          if (cancelled || programmaticDockMoveRef.current || modeTransitionRef.current) return;
+          clearDockMoveTimer();
+          dockMoveTimerRef.current = window.setTimeout(() => {
+            dockMoveTimerRef.current = null;
+            if (!cancelled) void evaluateOverlayDocking();
+          }, OVERLAY_DOCK_SETTLE_DELAY_MS);
+        });
+        if (cancelled) stopListening();
+        else unlistenMove = stopListening;
+      } catch (err) {
+        console.warn("[Overlay] listen for edge docking failed:", err);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unlistenMove?.();
+      clearDockMoveTimer();
+      clearDockHideTimer();
+      cancelDockAnimation();
+    };
+  }, []);
 
   // Config is updated in real-time via the Tauri event listener in globalConfig.ts
 
@@ -1176,14 +1543,26 @@ export function Overlay() {
           ? (useEnglish ? "Waiting for next forecast" : "等待下一条预报")
           : (useEnglish ? "Syncing" : "同步中");
 
+  function handleDockPointerEnter() {
+    pointerInsideDockRef.current = true;
+    if (dockStateRef.current) void revealDockedOverlay();
+  }
+
+  function handleDockPointerLeave() {
+    pointerInsideDockRef.current = false;
+    if (dockStateRef.current) scheduleDockHide();
+  }
+
   return (
     <div
-      className="h-screen w-screen overflow-hidden select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-[-3px]"
+      className="relative h-screen w-screen overflow-hidden select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-[-3px]"
       style={{
         ...surfaceOpacityVars(config?.overlay_opacity, theme),
       }}
       data-overlay-mode={displayMode}
       data-mini-layout={displayMode === "mini" ? miniLayout : undefined}
+      data-dock-edge={dockEdge ?? undefined}
+      data-dock-phase={dockPhase ?? undefined}
       role="region"
       tabIndex={0}
       aria-label={overlayModeToggleTitle}
@@ -1195,8 +1574,11 @@ export function Overlay() {
       onPointerMoveCapture={handleOverlayWindowPointerMoveCapture}
       onPointerUpCapture={finishOverlayWindowPointerGesture}
       onPointerCancelCapture={finishOverlayWindowPointerGesture}
+      onPointerEnter={handleDockPointerEnter}
+      onPointerLeave={handleDockPointerLeave}
       title={overlayModeToggleTitle}
     >
+      {dockEdge && <div className="overlay-dock-handle" aria-hidden="true" />}
       <div
         ref={overlayPanelRef}
         className={`overlay-window flex h-full w-full overflow-hidden ${

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -60,6 +60,42 @@ html, body, #root {
   content: none;
 }
 
+.overlay-dock-handle {
+  position: absolute;
+  z-index: 3;
+  border-radius: var(--radius-full);
+  background: var(--accent);
+  opacity: 0.38;
+  pointer-events: none;
+  transition: opacity var(--duration-fast) var(--ease-out-expo);
+}
+
+[data-dock-phase="hidden"] .overlay-dock-handle {
+  opacity: 0.82;
+}
+
+[data-dock-edge="left"] .overlay-dock-handle,
+[data-dock-edge="right"] .overlay-dock-handle {
+  top: 50%;
+  width: 3px;
+  height: min(34px, 60%);
+  transform: translateY(-50%);
+}
+
+[data-dock-edge="left"] .overlay-dock-handle { right: 2px; }
+[data-dock-edge="right"] .overlay-dock-handle { left: 2px; }
+
+[data-dock-edge="top"] .overlay-dock-handle,
+[data-dock-edge="bottom"] .overlay-dock-handle {
+  left: 50%;
+  width: min(42px, 60%);
+  height: 3px;
+  transform: translateX(-50%);
+}
+
+[data-dock-edge="top"] .overlay-dock-handle { bottom: 2px; }
+[data-dock-edge="bottom"] .overlay-dock-handle { top: 2px; }
+
 .border-subtle { border: 1px solid var(--border-default); }
 
 /* ── Tauri drag region ── */
@@ -1273,7 +1309,8 @@ html, body, #root {
 
 @media (prefers-reduced-motion: reduce) {
   .overlay-window,
-  .overlay-window * {
+  .overlay-window *,
+  .overlay-dock-handle {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;

--- a/src/utils/overlayDocking.test.ts
+++ b/src/utils/overlayDocking.test.ts
@@ -1,0 +1,105 @@
+import {
+  calculateOverlayDockAnimationDuration,
+  calculateOverlayDockPlacement,
+  easeOverlayDockProgress,
+  findOverlayDockEdge,
+  OVERLAY_DOCK_REVEAL_SIZE,
+} from "./overlayDocking";
+
+function assertEqual(actual: unknown, expected: unknown, message: string) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`FAIL: ${message}\nexpected=${JSON.stringify(expected)}\nactual=${JSON.stringify(actual)}`);
+  }
+  console.log(`PASS: ${message}`);
+}
+
+export function runTests() {
+  const workArea = { x: 0, y: 0, width: 2560, height: 1400 };
+  const size = { width: 320, height: 180 };
+
+  assertEqual(
+    findOverlayDockEdge({ x: 14, y: 300 }, size, workArea, 24),
+    "left",
+    "nearest left edge is detected inside the snap distance",
+  );
+  assertEqual(
+    findOverlayDockEdge({ x: 900, y: 700 }, size, workArea, 24),
+    null,
+    "a freely positioned overlay is not docked",
+  );
+  assertEqual(
+    calculateOverlayDockPlacement("right", { x: 2230, y: 1300 }, size, workArea, OVERLAY_DOCK_REVEAL_SIZE),
+    {
+      edge: "right",
+      visible: { x: 2240, y: 1220 },
+      hidden: { x: 2552, y: 1220 },
+    },
+    "right docking clamps the overlay and leaves an eight-pixel reveal strip",
+  );
+  assertEqual(
+    calculateOverlayDockPlacement("top", { x: -40, y: 2 }, size, workArea, OVERLAY_DOCK_REVEAL_SIZE),
+    {
+      edge: "top",
+      visible: { x: 0, y: 0 },
+      hidden: { x: 0, y: -172 },
+    },
+    "top docking clamps the perpendicular axis and hides by its height",
+  );
+  assertEqual(
+    calculateOverlayDockPlacement("left", { x: 3, y: 420 }, size, workArea, OVERLAY_DOCK_REVEAL_SIZE),
+    {
+      edge: "left",
+      visible: { x: 0, y: 420 },
+      hidden: { x: -312, y: 420 },
+    },
+    "left docking leaves its reveal strip on the screen",
+  );
+  assertEqual(
+    calculateOverlayDockPlacement("bottom", { x: 700, y: 1214 }, size, workArea, OVERLAY_DOCK_REVEAL_SIZE),
+    {
+      edge: "bottom",
+      visible: { x: 700, y: 1220 },
+      hidden: { x: 700, y: 1392 },
+    },
+    "bottom docking leaves its reveal strip above the work-area edge",
+  );
+  assertEqual(
+    {
+      shortReveal: calculateOverlayDockAnimationDuration(10, "reveal"),
+      fullReveal: calculateOverlayDockAnimationDuration(320, "reveal"),
+      shortHide: calculateOverlayDockAnimationDuration(10, "hide"),
+      fullHide: calculateOverlayDockAnimationDuration(320, "hide"),
+    },
+    { shortReveal: 320, fullReveal: 460, shortHide: 280, fullHide: 398 },
+    "dock motion duration scales with travel while reveal remains more deliberate than hide",
+  );
+  assertEqual(
+    {
+      revealStart: easeOverlayDockProgress(0, "reveal"),
+      revealMiddle: easeOverlayDockProgress(0.5, "reveal"),
+      revealEnd: easeOverlayDockProgress(1, "reveal"),
+      hideStart: easeOverlayDockProgress(0, "hide"),
+      hideMiddle: easeOverlayDockProgress(0.5, "hide"),
+      hideEnd: easeOverlayDockProgress(1, "hide"),
+    },
+    {
+      revealStart: 0,
+      revealMiddle: 0.875,
+      revealEnd: 1,
+      hideStart: 0,
+      hideMiddle: 0.5,
+      hideEnd: 1,
+    },
+    "reveal decelerates without the old quint snap while hide eases smoothly at both ends",
+  );
+}
+
+const g = globalThis as any;
+if (typeof g.process !== "undefined" && typeof g.process.argv !== "undefined") {
+  try {
+    runTests();
+  } catch (error) {
+    console.error(error);
+    g.process.exit(1);
+  }
+}

--- a/src/utils/overlayDocking.ts
+++ b/src/utils/overlayDocking.ts
@@ -1,0 +1,108 @@
+export type OverlayDockEdge = "left" | "right" | "top" | "bottom";
+
+export interface PhysicalPoint {
+  x: number;
+  y: number;
+}
+
+export interface PhysicalSize {
+  width: number;
+  height: number;
+}
+
+export interface PhysicalRect extends PhysicalPoint, PhysicalSize {}
+
+export interface OverlayDockPlacement {
+  edge: OverlayDockEdge;
+  visible: PhysicalPoint;
+  hidden: PhysicalPoint;
+}
+
+export const OVERLAY_DOCK_SNAP_DISTANCE = 24;
+export const OVERLAY_DOCK_REVEAL_SIZE = 8;
+
+export type OverlayDockMotion = "reveal" | "hide";
+
+const OVERLAY_DOCK_REVEAL_MIN_MS = 320;
+const OVERLAY_DOCK_REVEAL_MAX_MS = 480;
+const OVERLAY_DOCK_HIDE_MIN_MS = 280;
+const OVERLAY_DOCK_HIDE_MAX_MS = 410;
+
+function clamp(value: number, minimum: number, maximum: number) {
+  if (maximum < minimum) return minimum;
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+export function calculateOverlayDockAnimationDuration(
+  distance: number,
+  motion: OverlayDockMotion,
+): number {
+  const safeDistance = Math.max(0, Number.isFinite(distance) ? distance : 0);
+  if (motion === "hide") {
+    return Math.round(clamp(270 + safeDistance * 0.4, OVERLAY_DOCK_HIDE_MIN_MS, OVERLAY_DOCK_HIDE_MAX_MS));
+  }
+  return Math.round(clamp(300 + safeDistance * 0.5, OVERLAY_DOCK_REVEAL_MIN_MS, OVERLAY_DOCK_REVEAL_MAX_MS));
+}
+
+export function easeOverlayDockProgress(
+  progress: number,
+  motion: OverlayDockMotion,
+): number {
+  const t = clamp(progress, 0, 1);
+  if (motion === "hide") {
+    return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+  }
+  return 1 - Math.pow(1 - t, 3);
+}
+
+export function findOverlayDockEdge(
+  position: PhysicalPoint,
+  size: PhysicalSize,
+  workArea: PhysicalRect,
+  snapDistance: number,
+): OverlayDockEdge | null {
+  const right = workArea.x + workArea.width;
+  const bottom = workArea.y + workArea.height;
+  const candidates: Array<{ edge: OverlayDockEdge; distance: number }> = [
+    { edge: "left", distance: Math.abs(position.x - workArea.x) },
+    { edge: "right", distance: Math.abs(position.x + size.width - right) },
+    { edge: "top", distance: Math.abs(position.y - workArea.y) },
+    { edge: "bottom", distance: Math.abs(position.y + size.height - bottom) },
+  ];
+
+  candidates.sort((a, b) => a.distance - b.distance);
+  return candidates[0].distance <= snapDistance ? candidates[0].edge : null;
+}
+
+export function calculateOverlayDockPlacement(
+  edge: OverlayDockEdge,
+  position: PhysicalPoint,
+  size: PhysicalSize,
+  workArea: PhysicalRect,
+  revealSize: number,
+): OverlayDockPlacement {
+  const right = workArea.x + workArea.width;
+  const bottom = workArea.y + workArea.height;
+  const visible: PhysicalPoint = {
+    x: clamp(position.x, workArea.x, right - size.width),
+    y: clamp(position.y, workArea.y, bottom - size.height),
+  };
+
+  if (edge === "left") visible.x = workArea.x;
+  if (edge === "right") visible.x = right - size.width;
+  if (edge === "top") visible.y = workArea.y;
+  if (edge === "bottom") visible.y = bottom - size.height;
+
+  const revealed = Math.max(1, Math.min(revealSize, edge === "left" || edge === "right" ? size.width : size.height));
+  const hidden = { ...visible };
+  if (edge === "left") hidden.x = workArea.x - size.width + revealed;
+  if (edge === "right") hidden.x = right - revealed;
+  if (edge === "top") hidden.y = workArea.y - size.height + revealed;
+  if (edge === "bottom") hidden.y = bottom - revealed;
+
+  return { edge, visible, hidden };
+}
+
+export function pointDistance(a: PhysicalPoint, b: PhysicalPoint): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}

--- a/src/utils/overlayInteraction.test.ts
+++ b/src/utils/overlayInteraction.test.ts
@@ -36,6 +36,16 @@ export function runTests() {
     !overlaySource.includes("setResizable(false)"),
     "mini mode remains user-resizable after its preferred size is restored",
   );
+  assert(
+    overlaySource.includes("pendingPosition")
+      && overlaySource.includes("moveInFlight")
+      && overlaySource.includes("flushLatestPosition"),
+    "dock animation coalesces native window moves instead of accumulating stale frames",
+  );
+  assert(
+    !overlaySource.includes("const step = async"),
+    "dock animation clock is not blocked by awaited native position writes",
+  );
 }
 
 if (typeof g.process !== "undefined" && typeof g.process.argv !== "undefined") {

--- a/src/utils/overlaySizing.test.ts
+++ b/src/utils/overlaySizing.test.ts
@@ -2,7 +2,10 @@ import {
   calculateMiniOverlaySize,
   initialMiniOverlayLayout,
   MINI_OVERLAY_MIN_HEIGHT,
+  MINI_OVERLAY_SINGLE_MIN_HEIGHT,
+  MINI_OVERLAY_STACKED_MIN_HEIGHT,
   MINI_OVERLAY_STACKED_HEIGHT,
+  miniOverlayMinHeightForLayout,
   normalizeMiniOverlaySize,
   resolveMiniOverlayLayoutAfterResize,
 } from "./overlaySizing";
@@ -31,6 +34,16 @@ export function runTests() {
     "the two-row threshold is exactly twice the new minimum height",
   );
   assertEqual(
+    miniOverlayMinHeightForLayout("single"),
+    MINI_OVERLAY_SINGLE_MIN_HEIGHT,
+    "single-row mode owns the half-height minimum",
+  );
+  assertEqual(
+    miniOverlayMinHeightForLayout("stacked"),
+    MINI_OVERLAY_STACKED_MIN_HEIGHT,
+    "two-row mode keeps the full two-row minimum",
+  );
+  assertEqual(
     normalizeMiniOverlaySize({ width: 120, height: 4 }),
     { width: 200, height: 18 },
     "mini size respects the new half-height minimum",
@@ -54,6 +67,11 @@ export function runTests() {
     resolveMiniOverlayLayoutAfterResize("stacked", 37, 36),
     "single",
     "dragging down to the old minimum switches to one row",
+  );
+  assertEqual(
+    resolveMiniOverlayLayoutAfterResize("stacked", 38, 36.8),
+    "single",
+    "DPI rounding still allows a two-row window to enter one row",
   );
   assertEqual(
     resolveMiniOverlayLayoutAfterResize("single", 36, 36),

--- a/src/utils/overlaySizing.ts
+++ b/src/utils/overlaySizing.ts
@@ -6,8 +6,13 @@ export interface OverlaySize {
 export type MiniOverlayLayout = "single" | "stacked";
 
 export const MINI_OVERLAY_MIN_WIDTH = 200;
-export const MINI_OVERLAY_MIN_HEIGHT = 18;
-export const MINI_OVERLAY_STACKED_HEIGHT = MINI_OVERLAY_MIN_HEIGHT * 2;
+export const MINI_OVERLAY_SINGLE_MIN_HEIGHT = 18;
+export const MINI_OVERLAY_STACKED_MIN_HEIGHT = MINI_OVERLAY_SINGLE_MIN_HEIGHT * 2;
+export const MINI_OVERLAY_LAYOUT_THRESHOLD = MINI_OVERLAY_STACKED_MIN_HEIGHT;
+
+// Kept as compatibility aliases for the window configuration and older callers.
+export const MINI_OVERLAY_MIN_HEIGHT = MINI_OVERLAY_SINGLE_MIN_HEIGHT;
+export const MINI_OVERLAY_STACKED_HEIGHT = MINI_OVERLAY_LAYOUT_THRESHOLD;
 
 const MINI_OVERLAY_WIDTH_RATIO = 0.18;
 const MINI_OVERLAY_HEIGHT_RATIO = 0.08;
@@ -26,12 +31,18 @@ export function normalizeMiniOverlaySize(size: OverlaySize): OverlaySize {
   };
 }
 
+export function miniOverlayMinHeightForLayout(layout: MiniOverlayLayout): number {
+  return layout === "single"
+    ? MINI_OVERLAY_SINGLE_MIN_HEIGHT
+    : MINI_OVERLAY_STACKED_MIN_HEIGHT;
+}
+
 export function initialMiniOverlayLayout(
   height: number,
   layoutAtThreshold: MiniOverlayLayout = "single",
 ): MiniOverlayLayout {
-  if (height < MINI_OVERLAY_STACKED_HEIGHT) return "single";
-  if (height > MINI_OVERLAY_STACKED_HEIGHT) return "stacked";
+  if (height < MINI_OVERLAY_LAYOUT_THRESHOLD) return "single";
+  if (height > MINI_OVERLAY_LAYOUT_THRESHOLD) return "stacked";
   return layoutAtThreshold;
 }
 
@@ -40,10 +51,20 @@ export function resolveMiniOverlayLayoutAfterResize(
   previousHeight: number,
   nextHeight: number,
 ): MiniOverlayLayout {
-  if (nextHeight < previousHeight && nextHeight <= MINI_OVERLAY_STACKED_HEIGHT) {
+  // Windows rounds physical track sizes to whole pixels. At 125%-175% DPI a
+  // logical 36px minimum can therefore arrive as 36.x CSS pixels. The one-pixel
+  // tolerance lets a downward resize cross into the single row on those screens.
+  const dpiRoundingTolerance = 1;
+  if (
+    nextHeight < previousHeight
+    && nextHeight <= MINI_OVERLAY_LAYOUT_THRESHOLD + dpiRoundingTolerance
+  ) {
     return "single";
   }
-  if (nextHeight > previousHeight && nextHeight >= MINI_OVERLAY_STACKED_HEIGHT) {
+  if (
+    nextHeight > previousHeight
+    && nextHeight >= MINI_OVERLAY_LAYOUT_THRESHOLD
+  ) {
     return "stacked";
   }
   return currentLayout;


### PR DESCRIPTION
## 解决的问题

悬浮窗停靠在屏幕边缘时会占用桌面空间，迷你布局在较小高度下也缺少稳定的自适应行为；同时，现有 OCR 统计页的信息层级、筛选与数据操作能力有限，使用体验与主应用不一致。

## 主要改动

- 为展开和迷你悬浮窗增加四边吸附及自动隐藏，保留约 8px 触发边。
- 支持悬停抽出、移开隐藏以及向屏幕内部拖动解除吸附。
- 按当前显示器工作区处理多屏与任务栏边界，并兼容系统减少动态效果设置。
- 优化迷你悬浮窗的单行/双行高度阈值、尺寸约束和独立尺寸记忆。
- 重做本地 OCR 统计页，补充筛选、KPI、趋势、热力图、符文分析、截图画廊、记录管理及 CSV/JSON 导出。
- 让统计页跟随应用主题，并在开发模式优先使用工作区模板，避免读取陈旧构建副本。
- 更新 README 和用户手册，补充新交互、统计口径和排障说明。

## 数据与权限影响

- 未新增外部联网行为或系统权限。
- 统计数据仍保存在本机，统计页继续通过本机回环地址提供数据操作。
- 悬浮窗继续使用已有几何配置保存位置和尺寸。

## 验证

- npm ci
- npm test：通过
- npm run build：通过
- cargo test --lib：116 项通过，1 项需要管理员权限的 ETW 集成测试按设计忽略

## 已知限制

- 吸附后的窗口仅保留约 8px 触发边，需要将鼠标移至对应屏幕边缘才能抽出。
- 本 PR 未附静态截图；悬浮窗的核心变化为原生窗口移动与动态交互，已由几何、动画、拖拽和尺寸测试覆盖。