### PR TITLE
chore(release): prepare v0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d2rhub",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d2rhub",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d2rhub",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Windows multi-account manager and OCR run tracker for Diablo II: Resurrected",
   "license": "MIT",
   "repository": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "d2rhub"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d2rhub"
-version = "0.8.0"
+version = "0.8.1"
 description = "Diablo II Resurrected Multi-Account Manager"
 authors = ["D2RHub"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
     "productName": "D2RHub",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "identifier": "com.d2rhub.app",
     "build": {
         "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- bump the npm package and lock metadata from 0.8.0 to 0.8.1
- bump the Rust crate and lock metadata from 0.8.0 to 0.8.1
- bump the Tauri application version from 0.8.0 to 0.8.1
- prepare the release following the reliability, account-mode, overlay, statistics, and documentation merges in #9–#12

## Validation

- `npm ci` — clean dependency installation passed
- `npm test` — all frontend tests passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 116 passed, 1 elevated ETW test ignored as designed
- `npm run build:full` — Full MSI and NSIS packages created
- `npm run build:lite:nsis` — Lite NSIS package created

## Release content

The GitHub Release will follow the existing Chinese release-note structure and cover:

- ETW plus mutex-handle verification for reliable Token launch sequencing
- CN-only Battle.net compatibility mode and safe migration of legacy international accounts to Token mode
- four-edge overlay docking, smooth auto-hide behavior, and independent expanded/mini sizing
- continuous 20–40px single-row mini-overlay resizing on Windows high-DPI displays
- rebuilt local OCR statistics with filters, KPIs, trends, heatmaps, rune analysis, gallery, record management, and CSV/JSON exports
- refreshed README and user guide
- Full and Lite download descriptions plus SHA-256 checksums

## Release plan

After this PR passes the protected `verify` check and is merged:

1. update local `main` to the merge commit
2. rebuild Full and Lite NSIS installers from that exact commit
3. verify installer size and SHA-256
4. create tag `v0.8.1` and publish `Release v0.8.1`
5. upload `D2RHub_0.8.1_x64-setup.exe` and `D2RHub.Lite_0.8.1_x64-setup.exe`
6. verify the published release metadata and asset digests