### PR TITLE
chore(release): prepare v0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1>D2RHub</h1>
   <p><strong>Diablo II: Resurrected 多账号、双客户端与音频遥测刷图助手</strong></p>
   <p>
-    <img src="https://img.shields.io/badge/version-0.9.0-d5a85a" alt="Version 0.9.0" />
+    <img src="https://img.shields.io/badge/version-0.9.1-d5a85a" alt="Version 0.9.1" />
     <img src="https://img.shields.io/badge/platform-Windows_11-blue" alt="Windows 11" />
     <img src="https://img.shields.io/badge/game_memory-no_injection-2f855a" alt="No game-memory injection" />
     <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d2rhub",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d2rhub",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d2rhub",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Windows multi-account manager and audio telemetry run tracker for Diablo II: Resurrected",
   "license": "MIT",
   "repository": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "d2rhub"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d2rhub"
-version = "0.9.0"
+version = "0.9.1"
 description = "Diablo II Resurrected Multi-Account Manager"
 authors = ["D2RHub"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
     "productName": "D2RHub",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "identifier": "com.d2rhub.app",
     "build": {
         "frontendDist": "../dist",


### PR DESCRIPTION
## 内容

- 将 npm、Cargo 与 Tauri 应用版本统一更新为 `0.9.1`
- 更新 README 版本徽章
- 保持当前统一完整版构建，不恢复已移除的 Lite 构建配置

## 发布兼容策略

Release 构建完成后，将同一个完整版 NSIS 安装包同时以以下两个名称上传：

- `D2RHub_0.9.1_x64-setup.exe`
- `D2RHub.Lite_0.9.1_x64-setup.exe`

两个资产内容与 SHA-256 完全一致；Lite 名称仅用于兼容旧版用户的下载/升级习惯。

## 验证

- 远端 main CI：通过
- 前端测试：通过
- TypeScript 检查：通过
- Rust library tests：173 passed，3 ignored