### PR TITLE
fix(config): recover legacy migration and release v0.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1>D2RHub</h1>
   <p><strong>Diablo II: Resurrected 多账号、双客户端与音频遥测刷图助手</strong></p>
   <p>
-    <img src="https://img.shields.io/badge/version-0.9.3-d5a85a" alt="Version 0.9.3" />
+    <img src="https://img.shields.io/badge/version-0.9.4-d5a85a" alt="Version 0.9.4" />
     <img src="https://img.shields.io/badge/platform-Windows_11-blue" alt="Windows 11" />
     <img src="https://img.shields.io/badge/game_memory-no_injection-2f855a" alt="No game-memory injection" />
     <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d2rhub",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d2rhub",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d2rhub",
   "private": true,
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Windows multi-account manager and audio telemetry run tracker for Diablo II: Resurrected",
   "license": "MIT",
   "repository": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "d2rhub"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d2rhub"
-version = "0.9.3"
+version = "0.9.4"
 description = "Diablo II Resurrected Multi-Account Manager"
 authors = ["D2RHub"]
 edition = "2021"

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -989,6 +989,7 @@ pub fn delete_account(
     state.remove_active_game(&account_id);
 
     let updated_config = {
+        let _config_io = state.config_io.lock();
         let mut config = state.config.write();
         let cfg = config
             .as_mut()

--- a/src-tauri/src/commands/global_config.rs
+++ b/src-tauri/src/commands/global_config.rs
@@ -904,6 +904,405 @@ mod validation_tests {
         assert!(persisted.get("global_battle_net_path").is_none());
         let _ = std::fs::remove_dir_all(root);
     }
+
+    #[test]
+    fn config_save_rotates_the_previous_primary_into_a_backup() {
+        let root = temp_dir("global_config_backup_rotation");
+        let first = GlobalConfig {
+            theme: "light".to_string(),
+            ..GlobalConfig::default()
+        };
+        first.save(root.to_str().unwrap()).unwrap();
+        let second = GlobalConfig {
+            theme: "onyx".to_string(),
+            ..first.clone()
+        };
+        second.save(root.to_str().unwrap()).unwrap();
+
+        let primary: GlobalConfig =
+            serde_json::from_slice(&std::fs::read(root.join("global_config.json")).unwrap())
+                .unwrap();
+        let backup: GlobalConfig =
+            serde_json::from_slice(&std::fs::read(root.join("global_config.json.bak")).unwrap())
+                .unwrap();
+        assert_eq!(primary.theme, "onyx");
+        assert_eq!(backup.theme, "light");
+        assert!(!root.join("global_config.json.tmp").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn malformed_primary_recovers_the_last_good_backup_and_archives_the_bad_file() {
+        let root = temp_dir("malformed_primary_recovery");
+        let first = GlobalConfig {
+            theme: "light".to_string(),
+            ..GlobalConfig::default()
+        };
+        first.save(root.to_str().unwrap()).unwrap();
+        GlobalConfig {
+            theme: "onyx".to_string(),
+            ..first
+        }
+        .save(root.to_str().unwrap())
+        .unwrap();
+        std::fs::write(root.join("global_config.json"), "{broken").unwrap();
+
+        let recovered = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+
+        assert_eq!(recovered.theme, "light");
+        assert!(root.join("global_config.json.bak").is_file());
+        let corrupt = std::fs::read_dir(&root)
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("global_config.corrupt-"))
+            })
+            .unwrap();
+        assert_eq!(std::fs::read_to_string(corrupt).unwrap(), "{broken");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn wrong_field_type_also_recovers_from_the_last_good_backup() {
+        let root = temp_dir("wrong_field_type_recovery");
+        let first = GlobalConfig::default();
+        first.save(root.to_str().unwrap()).unwrap();
+        GlobalConfig {
+            theme: "onyx".to_string(),
+            ..first
+        }
+        .save(root.to_str().unwrap())
+        .unwrap();
+        let mut invalid: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(root.join("global_config.json")).unwrap())
+                .unwrap();
+        invalid["enable_overlay"] = serde_json::json!("not-a-boolean");
+        std::fs::write(
+            root.join("global_config.json"),
+            serde_json::to_vec_pretty(&invalid).unwrap(),
+        )
+        .unwrap();
+
+        let recovered = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+
+        assert_eq!(recovered.theme, GlobalConfig::default().theme);
+        assert!(std::fs::read_dir(&root).unwrap().flatten().any(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("global_config.corrupt-")
+        }));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn corrupt_primary_without_a_backup_fails_closed_and_stays_untouched() {
+        let root = temp_dir("corrupt_without_backup");
+        let config_path = root.join("global_config.json");
+        std::fs::write(&config_path, "{broken").unwrap();
+
+        assert!(GlobalConfig::load(root.to_str().unwrap()).is_err());
+        assert_eq!(std::fs::read_to_string(&config_path).unwrap(), "{broken");
+        assert!(!root.join("global_config.json.bak").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn wrong_legacy_path_type_fails_closed_instead_of_becoming_an_empty_path() {
+        let root = temp_dir("wrong_legacy_path_type");
+        let config_path = root.join("global_config.json");
+        let invalid = serde_json::json!({
+            "version": 1,
+            "game_path": 42,
+            "saved_games_path": r"C:\Saved Games\Diablo II Resurrected",
+            "battle_net_path": r"C:\Battle.net\Battle.net.exe",
+            "program_data_agent_path": r"C:\ProgramData\Battle.net\Agent",
+            "app_data_roaming_bnet_path": r"C:\Roaming\Battle.net",
+            "accounts_dir": r"C:\D2RHub\accounts",
+            "first_run_complete": true
+        });
+        let bytes = serde_json::to_vec_pretty(&invalid).unwrap();
+        std::fs::write(&config_path, &bytes).unwrap();
+
+        assert!(GlobalConfig::load(root.to_str().unwrap()).is_err());
+        assert_eq!(std::fs::read(&config_path).unwrap(), bytes);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn completed_marker_without_any_game_path_returns_to_setup_without_losing_settings() {
+        let root = temp_dir("completed_without_game_path");
+        let config_path = root.join("global_config.json");
+        let broken = GlobalConfig {
+            first_run_complete: true,
+            theme: "onyx".to_string(),
+            font_scale: "large".to_string(),
+            ..GlobalConfig::default()
+        };
+        std::fs::write(&config_path, serde_json::to_vec_pretty(&broken).unwrap()).unwrap();
+
+        let loaded = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+
+        assert!(!loaded.first_run_complete);
+        assert_eq!(loaded.theme, "onyx");
+        assert_eq!(loaded.font_scale, "large");
+        let persisted: GlobalConfig =
+            serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+        assert!(!persisted.first_run_complete);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn missing_primary_is_restored_from_the_last_good_backup() {
+        let root = temp_dir("missing_primary_recovery");
+        let first = GlobalConfig {
+            theme: "light".to_string(),
+            ..GlobalConfig::default()
+        };
+        first.save(root.to_str().unwrap()).unwrap();
+        GlobalConfig {
+            theme: "onyx".to_string(),
+            ..first
+        }
+        .save(root.to_str().unwrap())
+        .unwrap();
+        std::fs::remove_file(root.join("global_config.json")).unwrap();
+
+        let recovered = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+
+        assert_eq!(recovered.theme, "light");
+        assert!(root.join("global_config.json").is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn synced_staging_file_wins_when_save_was_interrupted_after_primary_rotation() {
+        let root = temp_dir("interrupted_after_primary_rotation");
+        let original = GlobalConfig {
+            theme: "light".to_string(),
+            ..GlobalConfig::default()
+        };
+        original.save(root.to_str().unwrap()).unwrap();
+        let latest = GlobalConfig {
+            theme: "onyx".to_string(),
+            ..original
+        };
+        std::fs::write(
+            root.join("global_config.json.tmp"),
+            serde_json::to_vec_pretty(&latest).unwrap(),
+        )
+        .unwrap();
+        std::fs::rename(
+            root.join("global_config.json"),
+            root.join("global_config.json.bak"),
+        )
+        .unwrap();
+
+        let recovered = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+
+        assert_eq!(recovered.theme, "onyx");
+        assert!(root.join("global_config.json").is_file());
+        assert!(!root.join("global_config.json.tmp").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn unreadable_backup_without_a_primary_fails_closed_instead_of_returning_defaults() {
+        let root = temp_dir("unreadable_backup_only");
+        let backup = root.join("global_config.json.bak");
+        std::fs::write(&backup, "{broken-backup").unwrap();
+
+        assert!(GlobalConfig::load(root.to_str().unwrap()).is_err());
+        assert_eq!(std::fs::read_to_string(&backup).unwrap(), "{broken-backup");
+        assert!(!root.join("global_config.json").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn future_config_version_fails_closed_even_when_an_older_backup_exists() {
+        let root = temp_dir("future_version");
+        let first = GlobalConfig::default();
+        first.save(root.to_str().unwrap()).unwrap();
+        GlobalConfig {
+            theme: "onyx".to_string(),
+            ..first
+        }
+        .save(root.to_str().unwrap())
+        .unwrap();
+        let config_path = root.join("global_config.json");
+        let mut future: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+        future["version"] = serde_json::json!(CURRENT_CONFIG_VERSION + 1);
+        future["future_only_setting"] = serde_json::json!("must-survive");
+        std::fs::write(&config_path, serde_json::to_vec_pretty(&future).unwrap()).unwrap();
+
+        assert!(GlobalConfig::load(root.to_str().unwrap()).is_err());
+        let preserved: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+        assert_eq!(preserved["version"], CURRENT_CONFIG_VERSION + 1);
+        assert_eq!(preserved["future_only_setting"], "must-survive");
+        assert!(root.join("global_config.json.bak").is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn real_v1_shape_migrates_without_requiring_modern_fields() {
+        let root = temp_dir("real_v1_shape");
+        let config_path = root.join("global_config.json");
+        let legacy = serde_json::json!({
+            "version": 1,
+            "battle_net_path": r"C:\Battle.net\Battle.net.exe",
+            "game_path": r"D:\Games\D2R-CN",
+            "saved_games_path": r"C:\Users\Tester\Saved Games\Diablo II Resurrected (CN)",
+            "program_data_agent_path": r"C:\ProgramData\Battle.net\Agent",
+            "app_data_roaming_bnet_path": r"C:\Users\Tester\AppData\Roaming\Battle.net",
+            "accounts_dir": r"D:\Portable\config\accounts",
+            "first_run_complete": true,
+            "theme": "onyx",
+            "enable_overlay": false,
+            "ocr_enabled": true,
+            "ocr_target_account": "acount1"
+        });
+        std::fs::write(&config_path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+
+        let config = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+
+        assert_eq!(config.version, CURRENT_CONFIG_VERSION);
+        assert_eq!(config.cn_game_path, r"D:\Games\D2R-CN");
+        assert_eq!(config.cn_battle_net_path, r"C:\Battle.net\Battle.net.exe");
+        assert_eq!(config.theme, "onyx");
+        assert!(!config.enable_tz_overlay);
+        assert!(!config.enable_stats_overlay);
+        assert!(config.legacy_path_migration.is_none());
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+        assert!(persisted.get("game_path").is_none());
+        assert!(persisted.get("ocr_enabled").is_none());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn hypothetical_v2_single_path_shape_uses_the_same_safe_migration() {
+        let root = temp_dir("v2_single_path_shape");
+        let config_path = root.join("global_config.json");
+        let legacy = serde_json::json!({
+            "version": 2,
+            "battle_net_path": r"C:\Battle.net\Battle.net.exe",
+            "game_path": r"D:\Games\D2R-Global",
+            "saved_games_path": r"C:\Users\Tester\Saved Games\Diablo II Resurrected",
+            "program_data_agent_path": r"C:\ProgramData\Battle.net\Agent",
+            "app_data_roaming_bnet_path": r"C:\Roaming\Battle.net",
+            "accounts_dir": r"D:\Portable\config\accounts",
+            "first_run_complete": true
+        });
+        std::fs::write(&config_path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+
+        let config = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+
+        assert_eq!(config.version, CURRENT_CONFIG_VERSION);
+        assert_eq!(config.global_game_path, r"D:\Games\D2R-Global");
+        assert!(config.cn_game_path.is_empty());
+        assert!(config.cn_battle_net_path.is_empty());
+        assert!(config.legacy_path_migration.is_none());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn real_v3_shape_removes_only_the_deprecated_global_battle_net_path() {
+        let root = temp_dir("real_v3_shape");
+        let config_path = root.join("global_config.json");
+        let legacy = serde_json::json!({
+            "version": 3,
+            "cn_battle_net_path": r"C:\Battle.net-CN\Battle.net.exe",
+            "cn_game_path": r"C:\Games\D2R-CN",
+            "cn_saved_games_path": r"C:\Saves\D2R-CN",
+            "global_battle_net_path": r"D:\Battle.net\Battle.net.exe",
+            "global_game_path": r"D:\Games\D2R-Global",
+            "global_saved_games_path": r"D:\Saves\D2R-Global",
+            "program_data_agent_path": r"C:\ProgramData\Battle.net\Agent",
+            "app_data_roaming_bnet_path": r"C:\Roaming\Battle.net",
+            "accounts_dir": r"D:\Portable\config\accounts",
+            "first_run_complete": true,
+            "enable_overlay": true,
+            "theme": "light"
+        });
+        std::fs::write(&config_path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+
+        let config = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+
+        assert_eq!(config.version, CURRENT_CONFIG_VERSION);
+        assert_eq!(
+            config.cn_battle_net_path,
+            r"C:\Battle.net-CN\Battle.net.exe"
+        );
+        assert_eq!(config.global_game_path, r"D:\Games\D2R-Global");
+        assert!(persisted.get("global_battle_net_path").is_none());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn v4_and_v5_shapes_gain_later_defaults_and_overlay_split_idempotently() {
+        for version in [4, 5] {
+            let root = temp_dir(&format!("real_v{version}_shape"));
+            let config_path = root.join("global_config.json");
+            let legacy = serde_json::json!({
+                "version": version,
+                "cn_battle_net_path": "",
+                "cn_game_path": "",
+                "cn_saved_games_path": "",
+                "global_game_path": r"D:\Games\D2R-Global",
+                "global_saved_games_path": r"D:\Saves\D2R-Global",
+                "program_data_agent_path": r"C:\ProgramData\Battle.net\Agent",
+                "app_data_roaming_bnet_path": r"C:\Roaming\Battle.net",
+                "accounts_dir": r"D:\Portable\config\accounts",
+                "first_run_complete": true,
+                "enable_overlay": false,
+                "theme": "light"
+            });
+            std::fs::write(&config_path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+
+            let first = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+            let first_bytes = std::fs::read(&config_path).unwrap();
+            let second = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+            let second_bytes = std::fs::read(&config_path).unwrap();
+
+            assert_eq!(first.version, CURRENT_CONFIG_VERSION);
+            assert!(!first.enable_tz_overlay);
+            assert!(!first.enable_stats_overlay);
+            assert_eq!(first.global_game_path, second.global_game_path);
+            assert_eq!(first_bytes, second_bytes);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn persisted_pending_marker_survives_restart_until_the_user_resolves_it() {
+        let root = temp_dir("persisted_pending_marker");
+        let config_path = root.join("global_config.json");
+        let pending = LegacyPathMigration {
+            game_path: r"D:\Unknown\D2R".to_string(),
+            saved_games_path: r"D:\Unknown\Saves".to_string(),
+            battle_net_path: r"D:\Unknown\Battle.net.exe".to_string(),
+        };
+        let config = GlobalConfig {
+            first_run_complete: true,
+            legacy_path_migration: Some(pending.clone()),
+            ..GlobalConfig::default()
+        };
+        std::fs::write(&config_path, serde_json::to_vec_pretty(&config).unwrap()).unwrap();
+
+        let loaded = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+
+        assert!(!loaded.first_run_complete);
+        assert_eq!(loaded.legacy_path_migration, Some(pending));
+        assert!(loaded.save(root.to_str().unwrap()).is_err());
+        let _ = std::fs::remove_dir_all(root);
+    }
 }
 
 /// 窗口几何信息（位置+尺寸持久化）
@@ -1012,23 +1411,166 @@ impl GlobalConfig {
         Path::new(app_data_dir).join("global_config.json")
     }
 
+    fn config_backup_path(app_data_dir: &str) -> PathBuf {
+        Path::new(app_data_dir).join("global_config.json.bak")
+    }
+
+    fn config_staging_path(app_data_dir: &str) -> PathBuf {
+        Path::new(app_data_dir).join("global_config.json.tmp")
+    }
+
+    fn unique_corrupt_config_path(app_data_dir: &str) -> PathBuf {
+        let dir = Path::new(app_data_dir);
+        let stem = format!("global_config.corrupt-{}", std::process::id());
+        for suffix in 0..1000 {
+            let name = if suffix == 0 {
+                format!("{stem}.json")
+            } else {
+                format!("{stem}-{suffix}.json")
+            };
+            let candidate = dir.join(name);
+            if !candidate.exists() {
+                return candidate;
+            }
+        }
+        dir.join(format!("{stem}-overflow.json"))
+    }
+
+    fn config_file_is_readable(path: &Path) -> bool {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|content| serde_json::from_str::<GlobalConfig>(&content).ok())
+            .is_some()
+    }
+
+    fn restore_missing_primary_from_backup(app_data_dir: &str) -> bool {
+        let path = Self::config_path(app_data_dir);
+        let backup = Self::config_backup_path(app_data_dir);
+        let staging = Self::config_staging_path(app_data_dir);
+        if path.exists() {
+            return false;
+        }
+
+        for candidate in [&staging, &backup] {
+            if !candidate.is_file() || !Self::config_file_is_readable(candidate) {
+                continue;
+            }
+            match std::fs::rename(candidate, &path) {
+                Ok(()) => {
+                    log::warn!("主配置缺失，已从 {} 恢复", candidate.display());
+                    return true;
+                }
+                Err(error) => {
+                    log::error!("从配置候选 {} 恢复失败: {error}", candidate.display());
+                }
+            }
+        }
+        false
+    }
+
+    fn archive_corrupt_primary_and_restore_backup(app_data_dir: &str) -> bool {
+        let path = Self::config_path(app_data_dir);
+        let backup = Self::config_backup_path(app_data_dir);
+        let staging = Self::config_staging_path(app_data_dir);
+        if !path.exists() {
+            return false;
+        }
+
+        let recovery = if backup.is_file() && Self::config_file_is_readable(&backup) {
+            &backup
+        } else if staging.is_file() && Self::config_file_is_readable(&staging) {
+            &staging
+        } else {
+            return false;
+        };
+
+        let corrupt = Self::unique_corrupt_config_path(app_data_dir);
+        if let Err(error) = std::fs::rename(&path, &corrupt) {
+            log::error!("归档损坏配置 {} 失败: {error}", path.display());
+            return false;
+        }
+        if let Err(error) = std::fs::rename(recovery, &path) {
+            let _ = std::fs::rename(&corrupt, &path);
+            log::error!("安装配置恢复候选 {} 失败: {error}", recovery.display());
+            return false;
+        }
+        log::warn!(
+            "主配置无法读取，已恢复可用候选；损坏文件保留在 {}",
+            corrupt.display()
+        );
+        true
+    }
+
     fn geometry_path(app_data_dir: &str) -> PathBuf {
         Path::new(app_data_dir).join("window_geometry.json")
     }
 
     /// 从磁盘加载配置
     pub fn load(app_data_dir: &str) -> Result<Self, AppError> {
+        Self::load_inner(app_data_dir, true)
+    }
+
+    fn load_inner(app_data_dir: &str, allow_backup_recovery: bool) -> Result<Self, AppError> {
         let path = Self::config_path(app_data_dir);
+        if allow_backup_recovery {
+            Self::restore_missing_primary_from_backup(app_data_dir);
+        }
         if !path.exists() {
+            let backup = Self::config_backup_path(app_data_dir);
+            let staging = Self::config_staging_path(app_data_dir);
+            if backup.exists() || staging.exists() {
+                return Err(AppError::ConfigReadError(
+                    "主配置缺失，且遗留的备份或暂存配置无法安全读取".to_string(),
+                ));
+            }
             return Ok(Self::default());
         }
         let content =
             std::fs::read_to_string(&path).map_err(|e| AppError::ConfigReadError(e.to_string()))?;
-        let mut value: serde_json::Value = serde_json::from_str(&content)?;
+        let mut value: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(value) => value,
+            Err(_error)
+                if allow_backup_recovery
+                    && Self::archive_corrupt_primary_and_restore_backup(app_data_dir) =>
+            {
+                return Self::load_inner(app_data_dir, false);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        if value
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|version| version > u64::from(CURRENT_CONFIG_VERSION))
+        {
+            return Err(AppError::ConfigReadError(format!(
+                "配置版本高于当前程序支持的 v{CURRENT_CONFIG_VERSION}，请使用更新版本的 D2RHub 打开"
+            )));
+        }
+        if let Some(invalid_key) = [
+            "game_path",
+            "saved_games_path",
+            "battle_net_path",
+            "global_battle_net_path",
+        ]
+        .into_iter()
+        .find(|key| value.get(*key).is_some_and(|field| !field.is_string()))
+        {
+            if allow_backup_recovery
+                && Self::archive_corrupt_primary_and_restore_backup(app_data_dir)
+            {
+                return Self::load_inner(app_data_dir, false);
+            }
+            return Err(AppError::ConfigReadError(format!(
+                "旧版配置字段 {invalid_key} 类型无效，已停止迁移以防数据丢失"
+            )));
+        }
         let legacy_overlay_enabled = value
             .get("enable_overlay")
             .and_then(serde_json::Value::as_bool)
             .unwrap_or_else(default_enable_overlay);
+        let had_raw_legacy_paths = value.get("game_path").is_some()
+            || value.get("saved_games_path").is_some()
+            || value.get("battle_net_path").is_some();
         let mut overlay_split_migrated = false;
         if let Some(object) = value.as_object_mut() {
             if !object.contains_key("enable_tz_overlay") {
@@ -1063,8 +1605,24 @@ impl GlobalConfig {
                 });
             }
         }
-        let mut config: GlobalConfig = serde_json::from_value(value)?;
-        config.legacy_path_migration = pending_legacy_paths;
+        let mut config: GlobalConfig = match serde_json::from_value(value) {
+            Ok(config) => config,
+            Err(_error)
+                if allow_backup_recovery
+                    && Self::archive_corrupt_primary_and_restore_backup(app_data_dir) =>
+            {
+                return Self::load_inner(app_data_dir, false);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let persisted_pending_paths = config.legacy_path_migration.take();
+        config.legacy_path_migration = pending_legacy_paths.or_else(|| {
+            if had_raw_legacy_paths {
+                None
+            } else {
+                persisted_pending_paths
+            }
+        });
 
         if config.version != CURRENT_CONFIG_VERSION {
             config.version = CURRENT_CONFIG_VERSION;
@@ -1097,6 +1655,15 @@ impl GlobalConfig {
         if config.normalize_rune_audio_configuration() {
             log::warn!("检测到无效的声纹目标配置，已自动关闭自动识别");
             migrated = true;
+        }
+
+        if config.first_run_complete
+            && config.cn_game_path.trim().is_empty()
+            && config.global_game_path.trim().is_empty()
+        {
+            config.first_run_complete = false;
+            migrated = true;
+            log::warn!("配置标记为已完成但没有任何游戏目录，已要求重新确认设置");
         }
 
         if config.legacy_path_migration.is_some() {
@@ -1311,8 +1878,35 @@ impl GlobalConfig {
             std::fs::create_dir_all(dir).map_err(|e| AppError::ConfigWriteError(e.to_string()))?;
         }
         let path = Self::config_path(app_data_dir);
+        let backup = Self::config_backup_path(app_data_dir);
+        let staging = Self::config_staging_path(app_data_dir);
         let content = serde_json::to_string_pretty(self)?;
-        std::fs::write(&path, content).map_err(|e| AppError::ConfigWriteError(e.to_string()))?;
+        if staging.exists() {
+            std::fs::remove_file(&staging)
+                .map_err(|e| AppError::ConfigWriteError(e.to_string()))?;
+        }
+        std::fs::write(&staging, content).map_err(|e| AppError::ConfigWriteError(e.to_string()))?;
+        if let Ok(file) = std::fs::OpenOptions::new().write(true).open(&staging) {
+            file.sync_all()
+                .map_err(|e| AppError::ConfigWriteError(e.to_string()))?;
+        }
+
+        let had_primary = path.exists();
+        if had_primary {
+            if backup.exists() {
+                std::fs::remove_file(&backup)
+                    .map_err(|e| AppError::ConfigWriteError(e.to_string()))?;
+            }
+            std::fs::rename(&path, &backup)
+                .map_err(|e| AppError::ConfigWriteError(e.to_string()))?;
+        }
+        if let Err(error) = std::fs::rename(&staging, &path) {
+            if had_primary {
+                let _ = std::fs::rename(&backup, &path);
+            }
+            let _ = std::fs::remove_file(&staging);
+            return Err(AppError::ConfigWriteError(error.to_string()));
+        }
         Ok(())
     }
 
@@ -1519,6 +2113,10 @@ pub fn get_global_config(state: tauri::State<'_, SharedState>) -> Result<GlobalC
         None => {
             // 首次调用，尝试从磁盘加载
             drop(config);
+            let _config_io = state.config_io.lock();
+            if let Some(loaded) = state.config.read().clone() {
+                return Ok(loaded);
+            }
             let loaded = GlobalConfig::load(&state.app_data_dir)?;
             let mut cfg = state.config.write();
             *cfg = Some(loaded.clone());
@@ -1533,9 +2131,19 @@ pub fn save_global_config(
     state: tauri::State<'_, SharedState>,
     config: GlobalConfig,
 ) -> Result<GlobalConfig, AppError> {
+    let _config_io = state.config_io.lock();
     if config.legacy_path_migration.is_some() {
         return Err(AppError::ConfigWriteError(
             "请先确认旧版路径属于国服还是国际服".to_string(),
+        ));
+    }
+    let existing_config_artifact = GlobalConfig::config_path(&state.app_data_dir).exists()
+        || GlobalConfig::config_backup_path(&state.app_data_dir).exists()
+        || GlobalConfig::config_staging_path(&state.app_data_dir).exists();
+    if state.config.read().is_none() && existing_config_artifact {
+        return Err(AppError::ConfigWriteError(
+            "现有配置未能安全加载，已阻止用新配置覆盖；请先检查日志和 global_config.json"
+                .to_string(),
         ));
     }
     let previous = state.config.read().clone();
@@ -1736,6 +2344,7 @@ pub fn save_theme(
     theme: String,
     window: tauri::Window,
 ) -> Result<(), AppError> {
+    let _config_io = state.config_io.lock();
     let mut config_lock = state.config.write();
     if let Some(ref mut cfg) = *config_lock {
         if window.label() == "overlay" {

--- a/src-tauri/src/commands/global_config.rs
+++ b/src-tauri/src/commands/global_config.rs
@@ -7,11 +7,29 @@ use crate::state::SharedState;
 
 const CURRENT_CONFIG_VERSION: u32 = 6;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum LegacyRegionPathMigration {
     NotNeeded,
     Migrated,
-    Ambiguous,
+    Pending(LegacyPathMigration),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LegacyBattleNetPathMigration {
+    changed: bool,
+    pending_path: Option<String>,
+}
+
+/// 无法自动判断归属的旧版单客户端路径。仅用于把迁移候选交给设置向导；
+/// 用户明确选择国服或国际服之前，不得写回并覆盖旧配置文件。
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LegacyPathMigration {
+    #[serde(default)]
+    pub game_path: String,
+    #[serde(default)]
+    pub saved_games_path: String,
+    #[serde(default)]
+    pub battle_net_path: String,
 }
 
 /// 全局配置
@@ -32,6 +50,9 @@ pub struct GlobalConfig {
     /// 国际服存档目录（亚服、美服、欧服共用）。
     #[serde(default)]
     pub global_saved_games_path: String,
+    /// 待用户确认归属的旧版路径。该状态存在时禁止持久化配置。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_path_migration: Option<LegacyPathMigration>,
     pub program_data_agent_path: String,
     pub app_data_roaming_bnet_path: String,
     pub accounts_dir: String,
@@ -241,7 +262,7 @@ fn should_validate_installation_paths(
 mod validation_tests {
     use super::{
         saved_games_settings_exists, should_validate_installation_paths,
-        validate_installation_paths, GlobalConfig, CURRENT_CONFIG_VERSION,
+        validate_installation_paths, GlobalConfig, LegacyPathMigration, CURRENT_CONFIG_VERSION,
     };
     use crate::commands::account::{AccountManager, AccountMeta};
 
@@ -665,6 +686,8 @@ mod validation_tests {
         let config_path = root.join("global_config.json");
         let mut legacy = serde_json::to_value(GlobalConfig {
             first_run_complete: true,
+            theme: "onyx".to_string(),
+            auto_close_browser: false,
             ..GlobalConfig::default()
         })
         .unwrap();
@@ -695,6 +718,17 @@ mod validation_tests {
         assert!(!config.first_run_complete);
         assert!(config.cn_game_path.is_empty());
         assert!(config.global_game_path.is_empty());
+        assert_eq!(config.theme, "onyx");
+        assert!(!config.auto_close_browser);
+        assert_eq!(
+            config.legacy_path_migration,
+            Some(LegacyPathMigration {
+                game_path: r"D:\Games\D2R".to_string(),
+                saved_games_path: r"D:\Saves\D2R".to_string(),
+                battle_net_path: r"D:\Battle.net\Battle.net.exe".to_string(),
+            })
+        );
+        assert!(config.save(root.to_str().unwrap()).is_err());
         let preserved: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
         assert_eq!(preserved["version"], 1);
@@ -736,7 +770,7 @@ mod validation_tests {
     }
 
     #[test]
-    fn ambiguous_legacy_battle_net_path_is_not_copied_to_two_editions() {
+    fn ambiguous_legacy_battle_net_path_is_returned_for_confirmation() {
         let mut legacy = serde_json::to_value(GlobalConfig::default()).unwrap();
         let object = legacy.as_object_mut().unwrap();
         object.remove("cn_battle_net_path");
@@ -761,10 +795,84 @@ mod validation_tests {
             serde_json::json!(r"D:\Saves\D2R-Global"),
         );
 
-        assert!(GlobalConfig::migrate_legacy_battle_net_paths(&mut legacy));
+        let migration = GlobalConfig::migrate_legacy_battle_net_paths(&mut legacy);
+        assert!(legacy.get("battle_net_path").is_some());
         let config: GlobalConfig = serde_json::from_value(legacy).unwrap();
 
         assert!(config.cn_battle_net_path.is_empty());
+        assert_eq!(
+            migration.pending_path.as_deref(),
+            Some(r"C:\Battle.net\Battle.net.exe")
+        );
+    }
+
+    #[test]
+    fn mixed_legacy_and_empty_new_keys_fill_the_new_profile() {
+        let root = temp_dir("mixed_empty_new_keys");
+        let config_path = root.join("global_config.json");
+        let mut mixed = serde_json::to_value(GlobalConfig::default()).unwrap();
+        let object = mixed.as_object_mut().unwrap();
+        object.insert("version".to_string(), serde_json::json!(1));
+        object.insert(
+            "game_path".to_string(),
+            serde_json::json!(r"D:\Games\D2R-CN"),
+        );
+        object.insert(
+            "saved_games_path".to_string(),
+            serde_json::json!(r"C:\Users\Tester\Saved Games\Diablo II Resurrected (CN)"),
+        );
+        object.insert(
+            "battle_net_path".to_string(),
+            serde_json::json!(r"C:\Battle.net\Battle.net.exe"),
+        );
+        std::fs::write(&config_path, serde_json::to_vec_pretty(&mixed).unwrap()).unwrap();
+
+        let config = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+        let persisted: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+
+        assert_eq!(config.cn_game_path, r"D:\Games\D2R-CN");
+        assert_eq!(config.cn_battle_net_path, r"C:\Battle.net\Battle.net.exe");
+        assert!(config.legacy_path_migration.is_none());
+        assert!(persisted.get("game_path").is_none());
+        assert!(persisted.get("battle_net_path").is_none());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn conflicting_mixed_paths_stay_pending_instead_of_dropping_the_legacy_value() {
+        let root = temp_dir("mixed_conflicting_keys");
+        let config_path = root.join("global_config.json");
+        let mut mixed = serde_json::to_value(GlobalConfig {
+            global_game_path: r"E:\Current\D2R".to_string(),
+            global_saved_games_path: r"C:\Users\Tester\Saved Games\Diablo II Resurrected"
+                .to_string(),
+            ..GlobalConfig::default()
+        })
+        .unwrap();
+        let object = mixed.as_object_mut().unwrap();
+        object.insert("version".to_string(), serde_json::json!(1));
+        object.insert("game_path".to_string(), serde_json::json!(r"D:\Legacy\D2R"));
+        object.insert(
+            "saved_games_path".to_string(),
+            serde_json::json!(r"C:\Users\Tester\Saved Games\Diablo II Resurrected"),
+        );
+        std::fs::write(&config_path, serde_json::to_vec_pretty(&mixed).unwrap()).unwrap();
+
+        let config = GlobalConfig::load(root.to_str().unwrap()).unwrap();
+        let preserved: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+
+        assert_eq!(config.global_game_path, r"E:\Current\D2R");
+        assert_eq!(
+            config
+                .legacy_path_migration
+                .as_ref()
+                .map(|candidate| candidate.game_path.as_str()),
+            Some(r"D:\Legacy\D2R")
+        );
+        assert_eq!(preserved["game_path"], r"D:\Legacy\D2R");
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -816,6 +924,7 @@ impl Default for GlobalConfig {
             cn_saved_games_path: String::new(),
             global_game_path: String::new(),
             global_saved_games_path: String::new(),
+            legacy_path_migration: None,
             program_data_agent_path: String::new(),
             app_data_roaming_bnet_path: String::new(),
             accounts_dir: String::new(),
@@ -938,14 +1047,24 @@ impl GlobalConfig {
             }
         }
         let region_path_migration = Self::migrate_legacy_region_paths(&mut value);
-        let preserve_ambiguous_legacy_paths =
-            region_path_migration == LegacyRegionPathMigration::Ambiguous;
-        let mut migrated =
-            overlay_split_migrated || region_path_migration == LegacyRegionPathMigration::Migrated;
-        if !preserve_ambiguous_legacy_paths {
-            migrated |= Self::migrate_legacy_battle_net_paths(&mut value);
+        let mut pending_legacy_paths = match &region_path_migration {
+            LegacyRegionPathMigration::Pending(candidate) => Some(candidate.clone()),
+            _ => None,
+        };
+        let mut migrated = overlay_split_migrated
+            || matches!(region_path_migration, LegacyRegionPathMigration::Migrated);
+        if pending_legacy_paths.is_none() {
+            let battle_net_migration = Self::migrate_legacy_battle_net_paths(&mut value);
+            migrated |= battle_net_migration.changed;
+            if let Some(battle_net_path) = battle_net_migration.pending_path {
+                pending_legacy_paths = Some(LegacyPathMigration {
+                    battle_net_path,
+                    ..LegacyPathMigration::default()
+                });
+            }
         }
         let mut config: GlobalConfig = serde_json::from_value(value)?;
+        config.legacy_path_migration = pending_legacy_paths;
 
         if config.version != CURRENT_CONFIG_VERSION {
             config.version = CURRENT_CONFIG_VERSION;
@@ -980,9 +1099,9 @@ impl GlobalConfig {
             migrated = true;
         }
 
-        if preserve_ambiguous_legacy_paths {
+        if config.legacy_path_migration.is_some() {
             config.first_run_complete = false;
-            log::warn!("旧版游戏与存档路径无法无歧义判断国服或国际服，保留原始配置并要求重新确认");
+            log::warn!("旧版路径无法无歧义迁移，保留原始配置并等待用户确认归属");
         } else if migrated {
             config.save(app_data_dir)?;
         }
@@ -993,37 +1112,71 @@ impl GlobalConfig {
         let Some(object) = value.as_object_mut() else {
             return LegacyRegionPathMigration::NotNeeded;
         };
-        if object.contains_key("cn_game_path")
-            || object.contains_key("global_game_path")
-            || (!object.contains_key("game_path") && !object.contains_key("saved_games_path"))
-        {
+        if !object.contains_key("game_path") && !object.contains_key("saved_games_path") {
             return LegacyRegionPathMigration::NotNeeded;
         }
 
-        let game_path = object
-            .get("game_path")
-            .and_then(|value| value.as_str().map(str::to_string))
-            .unwrap_or_default();
-        let saved_games_path = object
-            .get("saved_games_path")
-            .and_then(|value| value.as_str().map(str::to_string))
-            .unwrap_or_default();
-        let Some(edition) = Self::infer_legacy_saved_games_edition(&saved_games_path) else {
-            return LegacyRegionPathMigration::Ambiguous;
+        let legacy_string = |key: &str| {
+            object
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string()
         };
-        object.remove("game_path");
-        object.remove("saved_games_path");
+        let game_path = legacy_string("game_path");
+        let saved_games_path = legacy_string("saved_games_path");
+        let battle_net_path = legacy_string("battle_net_path");
+
+        if game_path.trim().is_empty() && saved_games_path.trim().is_empty() {
+            object.remove("game_path");
+            object.remove("saved_games_path");
+            return LegacyRegionPathMigration::Migrated;
+        }
+
+        let Some(edition) = Self::infer_legacy_saved_games_edition(&saved_games_path) else {
+            return LegacyRegionPathMigration::Pending(LegacyPathMigration {
+                game_path,
+                saved_games_path,
+                battle_net_path,
+            });
+        };
         let is_cn = edition == crate::launch_context::ClientEdition::Cn;
         let (game_key, saves_key) = if is_cn {
             ("cn_game_path", "cn_saved_games_path")
         } else {
             ("global_game_path", "global_saved_games_path")
         };
-        object.insert(game_key.to_string(), serde_json::Value::String(game_path));
-        object.insert(
-            saves_key.to_string(),
-            serde_json::Value::String(saved_games_path),
-        );
+
+        let conflicts_with_new_value = |key: &str, legacy: &str| {
+            !legacy.trim().is_empty()
+                && object
+                    .get(key)
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|current| {
+                        !current.trim().is_empty() && !current.eq_ignore_ascii_case(legacy)
+                    })
+        };
+        if conflicts_with_new_value(game_key, &game_path)
+            || conflicts_with_new_value(saves_key, &saved_games_path)
+        {
+            return LegacyRegionPathMigration::Pending(LegacyPathMigration {
+                game_path,
+                saved_games_path,
+                battle_net_path,
+            });
+        }
+
+        object.remove("game_path");
+        object.remove("saved_games_path");
+        for (key, legacy) in [(game_key, game_path), (saves_key, saved_games_path)] {
+            let current_is_empty = object
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .is_none_or(|current| current.trim().is_empty());
+            if current_is_empty {
+                object.insert(key.to_string(), serde_json::Value::String(legacy));
+            }
+        }
         object
             .entry(
                 if is_cn {
@@ -1063,23 +1216,34 @@ impl GlobalConfig {
         }
     }
 
-    fn migrate_legacy_battle_net_paths(value: &mut serde_json::Value) -> bool {
+    fn migrate_legacy_battle_net_paths(
+        value: &mut serde_json::Value,
+    ) -> LegacyBattleNetPathMigration {
         let Some(object) = value.as_object_mut() else {
-            return false;
+            return LegacyBattleNetPathMigration {
+                changed: false,
+                pending_path: None,
+            };
         };
-        let mut changed = object.remove("global_battle_net_path").is_some();
-        if object.contains_key("cn_battle_net_path") {
-            changed |= object.remove("battle_net_path").is_some();
-            return changed;
-        }
+        let changed = object.remove("global_battle_net_path").is_some();
         if !object.contains_key("battle_net_path") {
-            return changed;
+            return LegacyBattleNetPathMigration {
+                changed,
+                pending_path: None,
+            };
         }
 
         let battle_net_path = object
-            .remove("battle_net_path")
+            .get("battle_net_path")
             .and_then(|value| value.as_str().map(str::to_string))
             .unwrap_or_default();
+        if battle_net_path.trim().is_empty() {
+            object.remove("battle_net_path");
+            return LegacyBattleNetPathMigration {
+                changed: true,
+                pending_path: None,
+            };
+        }
         let cn_configured = ["cn_game_path", "cn_saved_games_path"].iter().any(|key| {
             object
                 .get(*key)
@@ -1095,19 +1259,53 @@ impl GlobalConfig {
                     .is_some_and(|path| !path.trim().is_empty())
             });
 
-        object.insert(
-            "cn_battle_net_path".to_string(),
-            serde_json::Value::String(if cn_configured && !global_configured {
-                battle_net_path
-            } else {
-                String::new()
-            }),
-        );
-        true
+        let current_cn_battle_net = object
+            .get("cn_battle_net_path")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+
+        if !current_cn_battle_net.trim().is_empty() {
+            object.remove("battle_net_path");
+            return LegacyBattleNetPathMigration {
+                changed: true,
+                pending_path: None,
+            };
+        }
+
+        if cn_configured && !global_configured {
+            object.remove("battle_net_path");
+            object.insert(
+                "cn_battle_net_path".to_string(),
+                serde_json::Value::String(battle_net_path),
+            );
+            return LegacyBattleNetPathMigration {
+                changed: true,
+                pending_path: None,
+            };
+        }
+
+        if global_configured && !cn_configured {
+            // 国际服从 v4 起仅支持 Token，旧 Battle.net 路径不再参与启动。
+            object.remove("battle_net_path");
+            return LegacyBattleNetPathMigration {
+                changed: true,
+                pending_path: None,
+            };
+        }
+
+        LegacyBattleNetPathMigration {
+            changed,
+            pending_path: Some(battle_net_path),
+        }
     }
 
     /// 保存配置到磁盘
     pub fn save(&self, app_data_dir: &str) -> Result<(), AppError> {
+        if self.legacy_path_migration.is_some() {
+            return Err(AppError::ConfigWriteError(
+                "旧版路径尚未确认归属，已阻止覆盖原配置".to_string(),
+            ));
+        }
         let dir = Path::new(app_data_dir);
         if !dir.exists() {
             std::fs::create_dir_all(dir).map_err(|e| AppError::ConfigWriteError(e.to_string()))?;
@@ -1334,7 +1532,12 @@ pub fn get_global_config(state: tauri::State<'_, SharedState>) -> Result<GlobalC
 pub fn save_global_config(
     state: tauri::State<'_, SharedState>,
     config: GlobalConfig,
-) -> Result<(), AppError> {
+) -> Result<GlobalConfig, AppError> {
+    if config.legacy_path_migration.is_some() {
+        return Err(AppError::ConfigWriteError(
+            "请先确认旧版路径属于国服还是国际服".to_string(),
+        ));
+    }
     let previous = state.config.read().clone();
     let mut cfg = config.clone();
     cfg.version = CURRENT_CONFIG_VERSION;
@@ -1360,7 +1563,7 @@ pub fn save_global_config(
     *stored = Some(cfg.clone());
     update_shortcut_map(&state, &cfg);
     crate::input_listener::set_bongo_cat_input_enabled(cfg.enable_bongo_cat);
-    Ok(())
+    Ok(cfg)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,10 +86,17 @@ pub fn run() {
     let app_state = Arc::new(AppState::new());
 
     // Load global config on startup to populate state and shortcut map cache early
-    if let Ok(cfg) = GlobalConfig::load(&app_state.app_data_dir) {
-        commands::global_config::update_shortcut_map(&app_state, &cfg);
-        let mut config_guard = app_state.config.write();
-        *config_guard = Some(cfg);
+    match GlobalConfig::load(&app_state.app_data_dir) {
+        Ok(cfg) => {
+            commands::global_config::update_shortcut_map(&app_state, &cfg);
+            let mut config_guard = app_state.config.write();
+            *config_guard = Some(cfg);
+        }
+        Err(error) => logger::log_msg(
+            "ERROR",
+            "Config",
+            &format!("全局配置加载失败，为防止覆盖已停止自动初始化: {error}"),
+        ),
     }
 
     // 从磁盘加载窗口几何并应用到初始窗口

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -41,6 +41,8 @@ pub struct AppState {
     pub shortcut_map: RwLock<HashMap<String, usize>>,
     /// 串行化窗口位置文件的迁移和写入，避免多个 WebView 同时读改写导致配置丢失。
     pub window_placement_io: Mutex<()>,
+    /// 串行化全局配置的加载迁移与原子写入，避免多个窗口争用同一暂存文件。
+    pub config_io: Mutex<()>,
 }
 
 impl AppState {
@@ -69,6 +71,7 @@ impl AppState {
             audio_mod_build_busy: AtomicBool::new(false),
             shortcut_map: RwLock::new(HashMap::new()),
             window_placement_io: Mutex::new(()),
+            config_io: Mutex::new(()),
         }
     }
 
@@ -153,8 +156,8 @@ fn directory_has_account_data(path: &Path) -> bool {
     })
 }
 
-fn directory_global_config_has_user_data(path: &Path) -> bool {
-    let Ok(content) = std::fs::read_to_string(path.join("global_config.json")) else {
+fn config_file_has_user_data(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
         return false;
     };
     let Ok(serde_json::Value::Object(object)) = serde_json::from_str(&content) else {
@@ -185,6 +188,16 @@ fn directory_global_config_has_user_data(path: &Path) -> bool {
             .and_then(serde_json::Value::as_str)
             .is_some_and(|value| !value.trim().is_empty())
     })
+}
+
+fn directory_global_config_has_user_data(path: &Path) -> bool {
+    [
+        "global_config.json",
+        "global_config.json.bak",
+        "global_config.json.tmp",
+    ]
+    .iter()
+    .any(|name| config_file_has_user_data(&path.join(name)))
 }
 
 fn directory_has_user_config(path: &Path) -> bool {
@@ -570,6 +583,38 @@ mod tests {
             "recoverable"
         );
         assert!(target.join("global_config.json").is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn valid_system_backup_prevents_an_older_portable_config_from_taking_over() {
+        let root = temp_dir("system_backup_is_user_data");
+        let source = root.join("portable").join("config");
+        let target = root.join("AppData").join("D2RHub");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(
+            source.join("global_config.json"),
+            r#"{"version":1,"first_run_complete":true,"game_path":"D:\\Old"}"#,
+        )
+        .unwrap();
+        std::fs::write(target.join("global_config.json"), "{broken").unwrap();
+        std::fs::write(
+            target.join("global_config.json.bak"),
+            r#"{"version":6,"first_run_complete":true,"cn_game_path":"C:\\Current"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::Conflict
+        );
+        assert_eq!(
+            std::fs::read_to_string(target.join("global_config.json")).unwrap(),
+            "{broken"
+        );
+        assert!(target.join("global_config.json.bak").is_file());
+        assert!(source.join("global_config.json").is_file());
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -128,23 +128,91 @@ fn copy_directory_recursive(source: &Path, target: &Path) -> std::io::Result<()>
     Ok(())
 }
 
-/// 仅在系统目录尚不存在、旧版 exe 同目录 `config` 存在时执行一次搬迁。
-/// 系统目录一旦存在便始终优先，避免升级时把新配置与旧配置静默合并。
-fn migrate_legacy_config_dir(source: &Path, target: &Path) -> Result<bool, String> {
-    if target.exists() {
-        return if target.is_dir() {
-            Ok(false)
-        } else {
-            Err(format!(
-                "系统配置路径已存在但不是目录: {}",
-                target.display()
-            ))
-        };
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LegacyConfigMigrationOutcome {
+    NotNeeded,
+    Migrated,
+    /// 两边都含用户配置，不能静默覆盖或合并。
+    Conflict,
+}
+
+fn directory_has_entries(path: &Path) -> bool {
+    std::fs::read_dir(path)
+        .ok()
+        .and_then(|mut entries| entries.next())
+        .is_some()
+}
+
+fn directory_has_account_data(path: &Path) -> bool {
+    let accounts = path.join("accounts");
+    std::fs::read_dir(accounts).ok().is_some_and(|entries| {
+        entries.flatten().any(|entry| {
+            entry.file_type().ok().is_some_and(|kind| kind.is_dir())
+                && entry.path().join("account.json").is_file()
+        })
+    })
+}
+
+fn directory_global_config_has_user_data(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path.join("global_config.json")) else {
+        return false;
+    };
+    let Ok(serde_json::Value::Object(object)) = serde_json::from_str(&content) else {
+        return false;
+    };
+    if object
+        .get("first_run_complete")
+        .and_then(serde_json::Value::as_bool)
+        == Some(true)
+    {
+        return true;
     }
+    [
+        "game_path",
+        "saved_games_path",
+        "battle_net_path",
+        "cn_game_path",
+        "cn_saved_games_path",
+        "cn_battle_net_path",
+        "global_game_path",
+        "global_saved_games_path",
+        "browser_path",
+    ]
+    .iter()
+    .any(|key| {
+        object
+            .get(*key)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    })
+}
+
+fn directory_has_user_config(path: &Path) -> bool {
+    directory_global_config_has_user_data(path) || directory_has_account_data(path)
+}
+
+fn unique_migration_backup_path(target: &Path) -> Result<PathBuf, String> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| format!("系统配置目录缺少父目录: {}", target.display()))?;
+    let stem = format!(".D2RHub.pre-migration-{}", std::process::id());
+    for suffix in 0..1000 {
+        let name = if suffix == 0 {
+            stem.clone()
+        } else {
+            format!("{stem}-{suffix}")
+        };
+        let candidate = parent.join(name);
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err("无法为现有系统配置分配迁移备份目录".to_string())
+}
+
+fn install_legacy_config_dir(source: &Path, target: &Path) -> Result<(), String> {
     if !source.is_dir() {
-        std::fs::create_dir_all(target)
-            .map_err(|error| format!("创建系统配置目录 {} 失败: {error}", target.display()))?;
-        return Ok(false);
+        return Err(format!("旧版配置目录不存在: {}", source.display()));
     }
 
     let parent = target
@@ -154,7 +222,7 @@ fn migrate_legacy_config_dir(source: &Path, target: &Path) -> Result<bool, Strin
         .map_err(|error| format!("创建系统配置父目录 {} 失败: {error}", parent.display()))?;
 
     match std::fs::rename(source, target) {
-        Ok(()) => Ok(true),
+        Ok(()) => Ok(()),
         Err(rename_error) => {
             // exe 与 AppData 可能位于不同磁盘；跨卷时先完整复制到同卷暂存目录，再原子安装。
             let staging = parent.join(format!(".D2RHub.migration-{}.tmp", std::process::id()));
@@ -190,9 +258,82 @@ fn migrate_legacy_config_dir(source: &Path, target: &Path) -> Result<bool, Strin
                     ),
                 );
             }
-            Ok(true)
+            Ok(())
         }
     }
+}
+
+/// 将旧版 exe 同目录 `config` 搬到系统配置目录。
+///
+/// 空目录或无法识别的半成品目标不能遮蔽完整旧配置；替换前会先留下可恢复备份。
+/// 两边都含用户配置时保留两边并报告冲突，绝不静默合并。
+fn migrate_legacy_config_dir(
+    source: &Path,
+    target: &Path,
+) -> Result<LegacyConfigMigrationOutcome, String> {
+    if target.exists() && !target.is_dir() {
+        return Err(format!(
+            "系统配置路径已存在但不是目录: {}",
+            target.display()
+        ));
+    }
+
+    if !source.is_dir() || !directory_has_entries(source) {
+        if !target.exists() {
+            std::fs::create_dir_all(target)
+                .map_err(|error| format!("创建系统配置目录 {} 失败: {error}", target.display()))?;
+        }
+        return Ok(LegacyConfigMigrationOutcome::NotNeeded);
+    }
+
+    if !target.exists() {
+        install_legacy_config_dir(source, target)?;
+        return Ok(LegacyConfigMigrationOutcome::Migrated);
+    }
+
+    if directory_has_user_config(target) {
+        return Ok(if directory_has_user_config(source) {
+            LegacyConfigMigrationOutcome::Conflict
+        } else {
+            LegacyConfigMigrationOutcome::NotNeeded
+        });
+    }
+
+    let target_was_empty = !directory_has_entries(target);
+    let backup = unique_migration_backup_path(target)?;
+    std::fs::rename(target, &backup).map_err(|error| {
+        format!(
+            "备份未完成的系统配置目录 {} 失败: {error}",
+            target.display()
+        )
+    })?;
+
+    if let Err(error) = install_legacy_config_dir(source, target) {
+        if target.exists() {
+            let _ = std::fs::remove_dir_all(target);
+        }
+        std::fs::rename(&backup, target).map_err(|restore_error| {
+            format!(
+                "{error}；恢复原系统配置目录 {} 也失败: {restore_error}",
+                target.display()
+            )
+        })?;
+        return Err(error);
+    }
+
+    if target_was_empty {
+        let _ = std::fs::remove_dir(&backup);
+    } else {
+        crate::logger::log_msg(
+            "WARN",
+            "Config",
+            &format!(
+                "未完成的系统配置已备份到 {}，旧版配置已接管",
+                backup.display()
+            ),
+        );
+    }
+    Ok(LegacyConfigMigrationOutcome::Migrated)
 }
 
 #[cfg(not(test))]
@@ -200,7 +341,7 @@ fn resolve_app_data_dir() -> PathBuf {
     let target = system_app_data_dir();
     let source = legacy_portable_config_dir();
     match migrate_legacy_config_dir(&source, &target) {
-        Ok(true) => crate::logger::log_msg(
+        Ok(LegacyConfigMigrationOutcome::Migrated) => crate::logger::log_msg(
             "INFO",
             "Config",
             &format!(
@@ -209,7 +350,16 @@ fn resolve_app_data_dir() -> PathBuf {
                 target.display()
             ),
         ),
-        Ok(false) => {}
+        Ok(LegacyConfigMigrationOutcome::Conflict) => crate::logger::log_msg(
+            "WARN",
+            "Config",
+            &format!(
+                "系统配置 {} 与旧版配置 {} 均包含用户数据；继续使用系统配置并保留旧目录，请勿手动覆盖",
+                target.display(),
+                source.display()
+            ),
+        ),
+        Ok(LegacyConfigMigrationOutcome::NotNeeded) => {}
         Err(error) => {
             crate::logger::log_msg(
                 "ERROR",
@@ -262,7 +412,9 @@ pub type SharedState = Arc<AppState>;
 
 #[cfg(test)]
 mod tests {
-    use super::{migrate_legacy_config_dir, AccountLifecycleLease, AppState};
+    use super::{
+        migrate_legacy_config_dir, AccountLifecycleLease, AppState, LegacyConfigMigrationOutcome,
+    };
 
     fn temp_dir(name: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!(
@@ -310,7 +462,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(migrate_legacy_config_dir(&source, &target).unwrap());
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::Migrated
+        );
         assert!(!source.exists());
         assert!(target.join("global_config.json").is_file());
         assert!(target
@@ -322,21 +477,99 @@ mod tests {
     }
 
     #[test]
-    fn existing_system_config_always_wins_over_legacy_directory() {
+    fn two_populated_config_directories_report_a_conflict_without_overwriting() {
         let root = temp_dir("system_wins");
         let source = root.join("portable").join("config");
         let target = root.join("AppData").join("D2RHub");
         std::fs::create_dir_all(&source).unwrap();
         std::fs::create_dir_all(&target).unwrap();
-        std::fs::write(source.join("global_config.json"), "legacy").unwrap();
-        std::fs::write(target.join("global_config.json"), "system").unwrap();
+        std::fs::write(
+            source.join("global_config.json"),
+            r#"{"version":1,"first_run_complete":true}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            target.join("global_config.json"),
+            r#"{"version":6,"first_run_complete":true}"#,
+        )
+        .unwrap();
 
-        assert!(!migrate_legacy_config_dir(&source, &target).unwrap());
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::Conflict
+        );
         assert_eq!(
             std::fs::read_to_string(target.join("global_config.json")).unwrap(),
-            "system"
+            r#"{"version":6,"first_run_complete":true}"#
         );
         assert!(source.join("global_config.json").is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn empty_system_directory_does_not_hide_legacy_config() {
+        let root = temp_dir("empty_system_directory");
+        let source = root.join("portable").join("config");
+        let target = root.join("AppData").join("D2RHub");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(
+            source.join("global_config.json"),
+            r#"{"version":1,"first_run_complete":true}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::Migrated
+        );
+        assert!(!source.exists());
+        assert_eq!(
+            std::fs::read_to_string(target.join("global_config.json")).unwrap(),
+            r#"{"version":1,"first_run_complete":true}"#
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn incomplete_system_directory_is_backed_up_before_legacy_config_takes_over() {
+        let root = temp_dir("incomplete_system_directory");
+        let source = root.join("portable").join("config");
+        let target = root.join("AppData").join("D2RHub");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(
+            source.join("global_config.json"),
+            r#"{"version":1,"first_run_complete":true}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            target.join("global_config.json"),
+            r#"{"version":6,"first_run_complete":false}"#,
+        )
+        .unwrap();
+        std::fs::write(target.join("interrupted.tmp"), "recoverable").unwrap();
+
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::Migrated
+        );
+        let parent = target.parent().unwrap();
+        let backup = std::fs::read_dir(parent)
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(".D2RHub.pre-migration-"))
+            })
+            .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(backup.join("interrupted.tmp")).unwrap(),
+            "recoverable"
+        );
+        assert!(target.join("global_config.json").is_file());
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -156,6 +156,27 @@ fn directory_has_account_data(path: &Path) -> bool {
     })
 }
 
+const LEGACY_MIGRATION_MARKER: &str = ".legacy-portable-config-migrated";
+
+fn normalized_path_identity(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .trim_end_matches(['\\', '/'])
+        .to_ascii_lowercase()
+}
+
+fn migration_marker_matches_source(source: &Path, target: &Path) -> bool {
+    std::fs::read_to_string(target.join(LEGACY_MIGRATION_MARKER))
+        .ok()
+        .is_some_and(|recorded| recorded.trim() == normalized_path_identity(source))
+}
+
+fn write_migration_marker(source_identity: &str, target: &Path) -> Result<(), String> {
+    std::fs::write(target.join(LEGACY_MIGRATION_MARKER), source_identity)
+        .map_err(|error| format!("写入旧版配置迁移标记失败: {error}"))
+}
+
 fn config_file_has_user_data(path: &Path) -> bool {
     let Ok(content) = std::fs::read_to_string(path) else {
         return false;
@@ -163,31 +184,16 @@ fn config_file_has_user_data(path: &Path) -> bool {
     let Ok(serde_json::Value::Object(object)) = serde_json::from_str(&content) else {
         return false;
     };
-    if object
-        .get("first_run_complete")
-        .and_then(serde_json::Value::as_bool)
-        == Some(true)
-    {
-        return true;
-    }
-    [
-        "game_path",
-        "saved_games_path",
-        "battle_net_path",
-        "cn_game_path",
-        "cn_saved_games_path",
-        "cn_battle_net_path",
-        "global_game_path",
-        "global_saved_games_path",
-        "browser_path",
-    ]
-    .iter()
-    .any(|key| {
-        object
-            .get(*key)
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| !value.trim().is_empty())
-    })
+    // 与 GlobalConfig::load 的完成条件保持一致：没有游戏目录的配置即使错误地
+    // 标记 first_run_complete=true，也仍是未完成配置，不能挡住便携版数据迁移。
+    ["game_path", "cn_game_path", "global_game_path"]
+        .iter()
+        .any(|key| {
+            object
+                .get(*key)
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty())
+        })
 }
 
 fn directory_global_config_has_user_data(path: &Path) -> bool {
@@ -276,6 +282,45 @@ fn install_legacy_config_dir(source: &Path, target: &Path) -> Result<(), String>
     }
 }
 
+fn replace_target_with_legacy_config(
+    source: &Path,
+    target: &Path,
+    source_identity: &str,
+) -> Result<(), String> {
+    let target_was_empty = !directory_has_entries(target);
+    let backup = unique_migration_backup_path(target)?;
+    std::fs::rename(target, &backup)
+        .map_err(|error| format!("备份现有系统配置目录 {} 失败: {error}", target.display()))?;
+
+    if let Err(error) = install_legacy_config_dir(source, target) {
+        if target.exists() {
+            let _ = std::fs::remove_dir_all(target);
+        }
+        std::fs::rename(&backup, target).map_err(|restore_error| {
+            format!(
+                "{error}；恢复原系统配置目录 {} 也失败: {restore_error}",
+                target.display()
+            )
+        })?;
+        return Err(error);
+    }
+
+    if let Err(error) = write_migration_marker(source_identity, target) {
+        crate::logger::log_msg("WARN", "Config", &error);
+    }
+
+    if target_was_empty {
+        let _ = std::fs::remove_dir(&backup);
+    } else {
+        crate::logger::log_msg(
+            "WARN",
+            "Config",
+            &format!("原系统配置已备份到 {}，旧版配置已接管", backup.display()),
+        );
+    }
+    Ok(())
+}
+
 /// 将旧版 exe 同目录 `config` 搬到系统配置目录。
 ///
 /// 空目录或无法识别的半成品目标不能遮蔽完整旧配置；替换前会先留下可恢复备份。
@@ -299,8 +344,27 @@ fn migrate_legacy_config_dir(
         return Ok(LegacyConfigMigrationOutcome::NotNeeded);
     }
 
+    let source_identity = normalized_path_identity(source);
+    if target.is_dir() && migration_marker_matches_source(source, target) {
+        return Ok(LegacyConfigMigrationOutcome::NotNeeded);
+    }
+
     if !target.exists() {
         install_legacy_config_dir(source, target)?;
+        if let Err(error) = write_migration_marker(&source_identity, target) {
+            crate::logger::log_msg("WARN", "Config", &error);
+        }
+        return Ok(LegacyConfigMigrationOutcome::Migrated);
+    }
+
+    let source_has_accounts = directory_has_account_data(source);
+    let target_has_accounts = directory_has_account_data(target);
+
+    // 修复已经进入混乱状态的安装：系统目录只有新建的全局配置、没有任何账号，
+    // 而便携目录仍保有账号时，应让便携目录接管。原系统目录会完整备份；迁移标记
+    // 可防止用户日后主动删除全部账号后，残留旧目录再次把账号复活。
+    if source_has_accounts && !target_has_accounts {
+        replace_target_with_legacy_config(source, target, &source_identity)?;
         return Ok(LegacyConfigMigrationOutcome::Migrated);
     }
 
@@ -312,40 +376,7 @@ fn migrate_legacy_config_dir(
         });
     }
 
-    let target_was_empty = !directory_has_entries(target);
-    let backup = unique_migration_backup_path(target)?;
-    std::fs::rename(target, &backup).map_err(|error| {
-        format!(
-            "备份未完成的系统配置目录 {} 失败: {error}",
-            target.display()
-        )
-    })?;
-
-    if let Err(error) = install_legacy_config_dir(source, target) {
-        if target.exists() {
-            let _ = std::fs::remove_dir_all(target);
-        }
-        std::fs::rename(&backup, target).map_err(|restore_error| {
-            format!(
-                "{error}；恢复原系统配置目录 {} 也失败: {restore_error}",
-                target.display()
-            )
-        })?;
-        return Err(error);
-    }
-
-    if target_was_empty {
-        let _ = std::fs::remove_dir(&backup);
-    } else {
-        crate::logger::log_msg(
-            "WARN",
-            "Config",
-            &format!(
-                "未完成的系统配置已备份到 {}，旧版配置已接管",
-                backup.display()
-            ),
-        );
-    }
+    replace_target_with_legacy_config(source, target, &source_identity)?;
     Ok(LegacyConfigMigrationOutcome::Migrated)
 }
 
@@ -498,12 +529,12 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         std::fs::write(
             source.join("global_config.json"),
-            r#"{"version":1,"first_run_complete":true}"#,
+            r#"{"version":1,"first_run_complete":true,"game_path":"D:\\OldD2R"}"#,
         )
         .unwrap();
         std::fs::write(
             target.join("global_config.json"),
-            r#"{"version":6,"first_run_complete":true}"#,
+            r#"{"version":6,"first_run_complete":true,"cn_game_path":"C:\\CurrentD2R"}"#,
         )
         .unwrap();
 
@@ -513,7 +544,7 @@ mod tests {
         );
         assert_eq!(
             std::fs::read_to_string(target.join("global_config.json")).unwrap(),
-            r#"{"version":6,"first_run_complete":true}"#
+            r#"{"version":6,"first_run_complete":true,"cn_game_path":"C:\\CurrentD2R"}"#
         );
         assert!(source.join("global_config.json").is_file());
         let _ = std::fs::remove_dir_all(root);
@@ -583,6 +614,138 @@ mod tests {
             "recoverable"
         );
         assert!(target.join("global_config.json").is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn invalid_completed_marker_without_game_paths_does_not_block_portable_config() {
+        let root = temp_dir("invalid_completed_marker");
+        let source = root.join("portable").join("config");
+        let target = root.join("AppData").join("D2RHub");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(
+            source.join("global_config.json"),
+            r#"{"version":3,"first_run_complete":true,"global_game_path":"D:\\D2R"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            target.join("global_config.json"),
+            r#"{"version":6,"first_run_complete":true,"cn_game_path":"","global_game_path":""}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::Migrated
+        );
+        assert!(target.join("global_config.json").is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn browser_only_initial_config_does_not_block_portable_config() {
+        let root = temp_dir("browser_only_initial_config");
+        let source = root.join("portable").join("config");
+        let target = root.join("AppData").join("D2RHub");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(
+            source.join("global_config.json"),
+            r#"{"version":3,"first_run_complete":true,"global_game_path":"D:\\D2R"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            target.join("global_config.json"),
+            r#"{"version":6,"first_run_complete":false,"browser_path":"C:\\Browser\\browser.exe"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::Migrated
+        );
+        assert!(target.join("global_config.json").is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn portable_accounts_recover_an_already_configured_but_accountless_system_dir() {
+        let root = temp_dir("recover_accountless_system_dir");
+        let source = root.join("portable").join("config");
+        let target = root.join("AppData").join("D2RHub");
+        std::fs::create_dir_all(source.join("accounts").join("acount1")).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(
+            source.join("global_config.json"),
+            r#"{"version":6,"first_run_complete":true,"cn_game_path":"D:\\PortableD2R"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            source.join("accounts").join("acount1").join("account.json"),
+            r#"{"id":"acount1","display_name":"portable"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            target.join("global_config.json"),
+            r#"{"version":6,"first_run_complete":true,"cn_game_path":"C:\\NewD2R"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::Migrated
+        );
+        assert!(target
+            .join("accounts")
+            .join("acount1")
+            .join("account.json")
+            .is_file());
+        assert!(target.join(super::LEGACY_MIGRATION_MARKER).is_file());
+        assert!(target
+            .parent()
+            .unwrap()
+            .read_dir()
+            .unwrap()
+            .flatten()
+            .any(|entry| entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".D2RHub.pre-migration-")));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn migration_marker_prevents_deleted_accounts_from_being_resurrected() {
+        let root = temp_dir("marker_prevents_resurrection");
+        let source = root.join("portable").join("config");
+        let target = root.join("AppData").join("D2RHub");
+        std::fs::create_dir_all(source.join("accounts").join("acount1")).unwrap();
+        std::fs::write(source.join("global_config.json"), "{}").unwrap();
+        std::fs::write(
+            source.join("accounts").join("acount1").join("account.json"),
+            r#"{"id":"acount1"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::Migrated
+        );
+
+        std::fs::remove_dir_all(target.join("accounts")).unwrap();
+        std::fs::create_dir_all(source.join("accounts").join("acount1")).unwrap();
+        std::fs::write(source.join("global_config.json"), "{}").unwrap();
+        std::fs::write(
+            source.join("accounts").join("acount1").join("account.json"),
+            r#"{"id":"acount1"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            migrate_legacy_config_dir(&source, &target).unwrap(),
+            LegacyConfigMigrationOutcome::NotNeeded
+        );
+        assert!(!target.join("accounts").exists());
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
     "productName": "D2RHub",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "identifier": "com.d2rhub.app",
     "build": {
         "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { UserPlus, Zap } from "lucide-react";
+import { AlertTriangle, UserPlus, Zap } from "lucide-react";
 import { useGlobalConfig, initConfigListener } from "./store/globalConfig";
 import { useAccounts } from "./store/accounts";
 import { syncThemeFromConfig } from "./store/theme";
@@ -46,7 +46,7 @@ type View =
   | { type: "main"; };
 
 function App() {
-  const { config, initialLoading, load, save } = useGlobalConfig();
+  const { config, initialLoading, error: configError, load, save } = useGlobalConfig();
   const { loadAccounts, accounts, deleteAccount, renameAccount, reorderAccounts } = useAccounts();
   const { launching, startLaunch, startBattleNetOnly, cancelLaunch, logs, clearLogs } = useLaunch();
 
@@ -180,6 +180,31 @@ function App() {
   const handleReconfigure = () => {
     setView({ type: "setup", existingConfig: config ?? undefined });
   };
+
+  if (!initialLoading && configError && !config) return (
+    <AppShell>
+      <div className="flex-1 flex items-center justify-center px-6">
+        <div className="w-[560px] account-line px-6 py-5">
+          <div className="flex items-start gap-3">
+            <div className="swiss-mark shrink-0">
+              <AlertTriangle size={16} className="text-error" strokeWidth={1.8} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-text-primary">配置文件无法安全读取</p>
+              <p className="text-sm text-text-secondary mt-2 leading-relaxed">
+                为避免默认值覆盖现有数据，D2RHub 已停止配置初始化。原文件仍保留；如果存在可用备份，程序会在启动时自动恢复。
+              </p>
+              <p className="text-xs font-mono text-error mt-3 break-all leading-relaxed">{configError}</p>
+              <button type="button" onClick={() => void invoke("open_logs_dir")}
+                className="control-btn h-9 mt-4">
+                打开日志目录
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AppShell>
+  );
 
   // ── loading ──
   if (view.type === "loading") return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,7 +149,9 @@ function App() {
   // Update view state
   useEffect(() => {
     if (initialLoading) return;
-    if (!config || !config.first_run_complete) setView({ type: "setup" });
+    if (!config || !config.first_run_complete) {
+      setView({ type: "setup", existingConfig: config ?? undefined });
+    }
     else setView({ type: "main" });
     // Sync theme from config (config as source of truth)
     if (config?.theme) syncThemeFromConfig(config.theme);

--- a/src/hooks/useAppEffects.ts
+++ b/src/hooks/useAppEffects.ts
@@ -249,7 +249,7 @@ export function useFirstLaunch(
   const firstLaunchOpenedRef = useRef(false);
 
   useEffect(() => {
-    if (loading || !config) return;
+    if (loading || !config || !config.first_run_complete) return;
     if (!config.first_launch) return;
     if (firstLaunchOpenedRef.current) return;
 
@@ -269,7 +269,7 @@ export function useFirstLaunch(
     }, 800);
 
     return () => clearTimeout(timer);
-  }, [loading, config?.first_launch, saveConfig]);
+  }, [loading, config?.first_launch, config?.first_run_complete, saveConfig]);
 }
 
 export function usePreventDragRegionDoubleClick() {

--- a/src/pages/SetupWizard.tsx
+++ b/src/pages/SetupWizard.tsx
@@ -5,6 +5,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useGlobalConfig } from "../store/globalConfig";
 import { showToast } from "../components/ui/Toast";
 import type { GlobalConfig } from "../store/types";
+import { resolveLegacyPathMigration, type LegacyPathResolution } from "../utils/legacyConfigMigration";
 
 interface Props { onComplete: () => void; initialConfig?: GlobalConfig; }
 
@@ -38,6 +39,12 @@ export function SetupWizard({ onComplete, initialConfig }: Props) {
   const [showError, setShowError] = useState(false);
   const [isCurrentStepValid, setIsCurrentStepValid] = useState(false);
   const [settingsJsonAvailable, setSettingsJsonAvailable] = useState<Record<"CN" | "Global", boolean | null>>({ CN: null, Global: null });
+  const pendingLegacyPaths = config.legacy_path_migration;
+
+  const applyLegacyPaths = (edition: LegacyPathResolution) => {
+    setConfig(current => resolveLegacyPathMigration(current, edition));
+    setCurrentStep(edition === "Global" ? 3 : 0);
+  };
 
   const handleSelectBrowser = async (btype: "chrome" | "edge") => {
     try {
@@ -212,6 +219,67 @@ export function SetupWizard({ onComplete, initialConfig }: Props) {
 
   const current = steps[currentStep];
 
+  if (pendingLegacyPaths) {
+    const candidates = [
+      ["游戏目录", pendingLegacyPaths.game_path],
+      ["存档目录", pendingLegacyPaths.saved_games_path],
+      ["Battle.net", pendingLegacyPaths.battle_net_path],
+    ].filter((entry): entry is [string, string] => Boolean(entry[1]));
+
+    return (
+      <div className="flex-1 flex items-center justify-center px-6">
+        <div className="w-[560px] account-line px-6 py-5">
+          <div className="flex items-start gap-3 mb-5">
+            <div className="swiss-mark shrink-0">
+              <AlertTriangle size={16} className="text-warning" strokeWidth={1.8} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-text-primary">确认旧版配置归属</p>
+              <p className="micro-meta mt-1 leading-relaxed">
+                旧版只保存了一套客户端路径，无法自动判断是国服还是国际服。确认前原配置文件不会被覆盖。
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-2 mb-5">
+            {candidates.map(([label, value]) => (
+              <div key={label} className="rounded-card px-3.5 py-3"
+                style={{ background: "var(--surface-tile-soft, var(--surface-card))", border: "1px solid var(--border-default)" }}>
+                <p className="micro-meta mb-1">{label}</p>
+                <p className="text-xs font-mono text-text-secondary break-all leading-relaxed">{value}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 mb-3">
+            <button type="button" onClick={() => applyLegacyPaths("CN")}
+              className="primary-cta h-10 justify-center">归为国服配置</button>
+            <button type="button" onClick={() => applyLegacyPaths("Global")}
+              className="control-btn h-10 justify-center">归为国际服配置</button>
+          </div>
+          <button type="button" onClick={() => applyLegacyPaths("keep")}
+            className="control-btn h-9 w-full justify-center">
+            保留当前新版路径，稍后手动检查
+          </button>
+          <p className="text-xs text-text-muted mt-3 leading-relaxed">
+            国际服仅使用 Token 直启，因此选择国际服时不会迁移旧 Battle.net 路径。其它主题、快捷键、悬浮窗和音频设置均保持不变。
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const setupTitle = initialConfig?.legacy_path_migration
+    ? "完成旧配置迁移"
+    : initialConfig?.first_run_complete
+      ? "重新配置"
+      : "初始设置";
+  const setupDescription = initialConfig?.legacy_path_migration
+    ? "确认路径后保存，其它设置不会改变"
+    : initialConfig?.first_run_complete
+      ? "修改路径后保存即可生效"
+      : "配置游戏路径，只需一次";
+
   return (
     <div className="flex-1 flex items-center justify-center px-6">
       <div className="w-[520px] account-line px-6 py-5">
@@ -220,8 +288,8 @@ export function SetupWizard({ onComplete, initialConfig }: Props) {
             <Wrench size={16} className="text-text-secondary" strokeWidth={1.8} />
           </div>
           <div className="min-w-0">
-            <p className="text-sm font-semibold text-text-primary">{initialConfig ? "重新配置" : "初始设置"}</p>
-            <p className="micro-meta mt-1">{initialConfig ? "修改路径后保存即可生效" : "配置游戏路径，只需一次"}</p>
+            <p className="text-sm font-semibold text-text-primary">{setupTitle}</p>
+            <p className="micro-meta mt-1">{setupDescription}</p>
           </div>
         </div>
 

--- a/src/store/globalConfig.ts
+++ b/src/store/globalConfig.ts
@@ -37,9 +37,9 @@ export const useGlobalConfig = create<GlobalConfigState>((set) => ({
   save: async (config: GlobalConfig) => {
     set({ saving: true, error: null });
     try {
-      await invoke("save_global_config", { config });
-      set({ config, saving: false });
-      await emit("global-config-updated", config);
+      const saved = await invoke<GlobalConfig>("save_global_config", { config });
+      set({ config: saved, saving: false });
+      await emit("global-config-updated", saved);
     } catch (e) {
       set({ error: String(e), saving: false });
       throw e;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,5 +1,11 @@
 // ── 数据模型 ──
 
+export interface LegacyPathMigration {
+  game_path: string;
+  saved_games_path: string;
+  battle_net_path: string;
+}
+
 export interface GlobalConfig {
   version: number;
   cn_battle_net_path: string;
@@ -7,6 +13,7 @@ export interface GlobalConfig {
   cn_saved_games_path: string;
   global_game_path: string;
   global_saved_games_path: string;
+  legacy_path_migration?: LegacyPathMigration | null;
   program_data_agent_path: string;
   app_data_roaming_bnet_path: string;
   accounts_dir: string;

--- a/src/utils/legacyConfigMigration.test.ts
+++ b/src/utils/legacyConfigMigration.test.ts
@@ -1,0 +1,70 @@
+import type { GlobalConfig } from "../store/types";
+import { resolveLegacyPathMigration } from "./legacyConfigMigration";
+
+function config(overrides: Partial<GlobalConfig> = {}): GlobalConfig {
+  return {
+    version: 6,
+    cn_battle_net_path: "",
+    cn_game_path: "",
+    cn_saved_games_path: "",
+    global_game_path: "",
+    global_saved_games_path: "",
+    legacy_path_migration: {
+      game_path: "D:/Legacy/D2R",
+      saved_games_path: "D:/Legacy/Saves",
+      battle_net_path: "D:/Legacy/Battle.net.exe",
+    },
+    program_data_agent_path: "C:/ProgramData/Battle.net/Agent",
+    app_data_roaming_bnet_path: "C:/Roaming/Battle.net",
+    accounts_dir: "C:/D2RHub/accounts",
+    first_run_complete: false,
+    browser_path: "C:/Browser/msedge.exe",
+    browser_type: "edge",
+    enable_bongo_cat: false,
+    bongo_cat_chatterbox: true,
+    bongo_cat_scale: 1,
+    bongo_cat_skin: "original",
+    bongo_cat_unlocked_skins: ["original"],
+    enable_overlay: true,
+    enable_tz_overlay: false,
+    enable_stats_overlay: true,
+    theme: "onyx",
+    theme_overlay: "light",
+    auto_close_browser: false,
+    enable_auto_update: false,
+    first_launch: false,
+    rune_audio_enabled: false,
+    rune_audio_target_account: "",
+    rune_audio_tracked_categories: ["runes"],
+    shortcut_bindings_json: "{}",
+    overlay_opacity: 81,
+    main_opacity: 92,
+    font_scale: "large",
+    ...overrides,
+  };
+}
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(`FAIL: ${message}`);
+  console.log(`PASS: ${message}`);
+}
+
+const original = config();
+const cn = resolveLegacyPathMigration(original, "CN");
+assert(cn.cn_game_path === "D:/Legacy/D2R", "CN confirmation maps the legacy game path");
+assert(cn.cn_saved_games_path === "D:/Legacy/Saves", "CN confirmation maps the legacy save path");
+assert(cn.cn_battle_net_path === "D:/Legacy/Battle.net.exe", "CN confirmation maps Battle.net");
+assert(cn.legacy_path_migration === null, "CN confirmation clears the pending migration marker");
+assert(cn.theme === original.theme && cn.overlay_opacity === original.overlay_opacity,
+  "migration confirmation preserves unrelated appearance settings");
+
+const global = resolveLegacyPathMigration(original, "Global");
+assert(global.global_game_path === "D:/Legacy/D2R", "Global confirmation maps the legacy game path");
+assert(global.global_saved_games_path === "D:/Legacy/Saves", "Global confirmation maps the legacy save path");
+assert(global.cn_battle_net_path === "", "Global confirmation does not reuse deprecated Battle.net auth");
+
+const current = config({ cn_game_path: "C:/Current/D2R-CN", global_game_path: "E:/Current/D2R" });
+const kept = resolveLegacyPathMigration(current, "keep");
+assert(kept.cn_game_path === current.cn_game_path && kept.global_game_path === current.global_game_path,
+  "keeping current paths only clears the migration marker");
+assert(original.legacy_path_migration !== null, "resolving a migration does not mutate the loaded config");

--- a/src/utils/legacyConfigMigration.ts
+++ b/src/utils/legacyConfigMigration.ts
@@ -1,0 +1,23 @@
+import type { GlobalConfig } from "../store/types";
+
+export type LegacyPathResolution = "CN" | "Global" | "keep";
+
+/** Apply an explicit user decision without touching unrelated configuration fields. */
+export function resolveLegacyPathMigration(
+  current: GlobalConfig,
+  resolution: LegacyPathResolution,
+): GlobalConfig {
+  const candidate = current.legacy_path_migration;
+  if (!candidate) return current;
+
+  const resolved: GlobalConfig = { ...current, legacy_path_migration: null };
+  if (resolution === "CN") {
+    if (candidate.game_path) resolved.cn_game_path = candidate.game_path;
+    if (candidate.saved_games_path) resolved.cn_saved_games_path = candidate.saved_games_path;
+    if (candidate.battle_net_path) resolved.cn_battle_net_path = candidate.battle_net_path;
+  } else if (resolution === "Global") {
+    if (candidate.game_path) resolved.global_game_path = candidate.game_path;
+    if (candidate.saved_games_path) resolved.global_saved_games_path = candidate.saved_games_path;
+  }
+  return resolved;
+}


### PR DESCRIPTION
## Summary

- make legacy portable config migration preserve and recover ambiguous old path data
- migrate portable accounts when the system directory is unconfigured or has zero accounts
- back up incomplete/conflicting system state and mark completed migrations to prevent account resurrection
- harden global config writes with atomic staging, backup recovery, corruption archiving, fail-closed UI, and serialized writes
- cover historical v1-v6 configs, mixed schemas, corrupt files, interrupted writes, and repeated startup
- prepare release v0.9.4

## Verification

- Rust: 205 passed, 3 ignored
- frontend tests passed
- TypeScript check passed
- production frontend build passed
- desktop Release, MSI, and NSIS bundles built successfully
- standard and Lite-compatible NSIS assets are byte-identical
- SHA-256: 3184B219008334CFDA7F73D76A024F91C0A8134060CB202AC1D5DDD31F623625